### PR TITLE
Add initial release version for Read the Docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,8 @@
 import datetime
 import sys
 # Update later when package implemented
-version = "0.1.0"
-release = "0.1.0"
+version = "0.0.1"
+release = "0.0.1"
 
 try:
     from sphinx_astropy.conf.v1 import *  # noqa
@@ -30,10 +30,10 @@ except ImportError:
 # Configuration for intersphinx
 intersphinx_mapping = {
     'jdaviz': ('https://jdaviz.readthedocs.io/en/latest/', None),
-     'python': ('https://docs.python.org/3/',
-                (None, 'http://data.astropy.org/intersphinx/python3.inv')),
-     'astropy': ('https://docs.astropy.org/en/stable/', None)
-    }
+    'python': ('https://docs.python.org/3/',
+               (None, 'http://data.astropy.org/intersphinx/python3.inv')),
+    'astropy': ('https://docs.astropy.org/en/stable/', None)
+}
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "mast-aladin-lite"
+version = "0.0.1"
 description = "Visualize MAST data products in Aladin Lite"
 requires-python = ">=3.10"
 authors = [


### PR DESCRIPTION
Currently, `pyproject.toml` lacks a version number, causing RTD build issues. 
This commit adds a static version as a temporary fix. 
A follow-up will be needed to implement dynamic versioning.

```
ValueError: invalid pyproject.toml config: `project`.
--
46 | configuration error: `project` must contain ['version'] properties
47 | [end of output]

```