### PR TITLE
CST-134 subclass Aladin app in mast-aladin-lite

### DIFF
--- a/mast_aladin_lite/app.py
+++ b/mast_aladin_lite/app.py
@@ -1,0 +1,5 @@
+from ipyaladin import Aladin
+
+
+class MastAladin(Aladin):
+    pass


### PR DESCRIPTION
first attempt to create the class `MastAladin` by subclassing `ipyaladin.Aladin`