### PR TITLE
Prep for first release to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,12 +39,13 @@ jobs:
     - name: Check dist
       run: python -m twine check --strict dist/*
 
-    - name: Test package
-      run: |
-        cd ..
-        python -m venv testenv
-        testenv/bin/pip install pytest pytest-astropy pytest-tornasync mast-aladin-lite/dist/*.whl
-        testenv/bin/python -c "import mast_aladin_lite; mast_aladin_lite.test()"
+ # Uncomment after adding first round of tests.
+    # - name: Test package
+    #   run: |
+    #     cd ..
+    #     python -m venv testenv
+    #     testenv/bin/pip install pytest pytest-astropy pytest-tornasync mast-aladin-lite/dist/*.whl
+    #     testenv/bin/python -c "import mast_aladin_lite; mast_aladin_lite.test()"
 
     # NOTE: Do not run this part for PR testing.
     - name: Publish distribution 📦 to PyPI

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 Welcome to mast-aladin-lite's documentation!
-===========================================
+============================================
 
 .. toctree::
    :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,14 @@ dependencies = [
     "astroquery",
     "sidecar",
 ]
-
 dynamic = [
     "version",
+]
+
+[project.optional-dependencies]
+docs = [
+    "sphinx-astropy[confv2]>=1.9.1",
+    "sphinx_design"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
 name = "mast-aladin-lite"
-version = "0.0.1"
 description = "Visualize MAST data products in Aladin Lite"
 requires-python = ">=3.10"
 authors = [
@@ -10,6 +9,10 @@ dependencies = [
     "ipyaladin",
     "astroquery",
     "sidecar",
+]
+
+dynamic = [
+    "version",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR is a follow-up effort toward achieving the first release on PyPI. It introduces dynamic versioning to automatically retrieve the version from the Git tag. Additionally, it disables test execution for the initial release, which can be re-enabled once tests are added.