### PR TITLE
CST-141_adding_devdeps_tests

### DIFF
--- a/.bandit.yaml
+++ b/.bandit.yaml
@@ -1,0 +1,5 @@
+exclude_dirs:
+  - mast_aladin_lite/tests
+
+# skip warning about asserts - they are used as behavior checks not as code tools
+skips: ['B101']

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+# flake8 does not support pyproject.toml (https://github.com/PyCQA/flake8/issues/234)
+
+[flake8]
+max-line-length = 100
+# E123: closing bracket does not match indentation of opening bracket's line
+# E126: continuation line over-indented for hanging indent
+# E226: missing whitespace around arithmetic operator
+# E402: module level import not at top of file
+# W503: line break before binary operator
+# W504: line break after binary operator
+ignore = E123,E126,E226,E402,W503,W504
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 90%
+        threshold: 0.01%

--- a/mast_aladin_lite/tests/example_test.py
+++ b/mast_aladin_lite/tests/example_test.py
@@ -1,0 +1,11 @@
+import pytest
+from app import MastAladin
+
+
+@pytest.fixture
+def MastAladin_helper():
+    return MastAladin()
+
+
+def test_calling_app(MastAladin_helper):
+    assert MastAladin_helper is MastAladin()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dynamic = [
 ]
 
 [project.optional-dependencies]
+test = [
+    "pytest"
+]
 docs = [
     "sphinx-astropy[confv2]>=1.9.1",
     "sphinx_design"

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ extras =
     test
 
 commands =
-    jupyter --paths
+    #jupyter --paths
     pip freeze
     cov: pytest --pyargs mast_aladin_lite {toxinidir}/docs --cov mast_aladin_lite --cov-config={toxinidir}/pyproject.toml
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ description = Run tests for mast-aladin-lite
 setenv =
     MPLBACKEND=agg
     JUPYTER_PLATFORM_DIRS=1
-    ## devdeps:  PIP_EXTRA_INDEX_URL = 
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ skip_install = true
 changedir = .
 description = security audit with bandit
 deps = bandit
-commands = bandit -r mast_aladin_lite
+commands = bandit -r mast_aladin_lite -c .bandit.yaml
 
 [testenv:pep517]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,11 @@
 [tox]
-envlist = py310-test, py311-test, linkcheck, codestyle, pep517, securityaudit
+envlist = 
+    py310-test-devdeps
+    py311-test-devdeps
+    linkcheck
+    codestyle
+    pep517
+    securityaudit
 
 requires =
     setuptools >= 30.3.0
@@ -8,10 +14,11 @@ isolated_build = true
 
 [testenv]
 description = Run tests for mast-aladin-lite
-
+# Suppress display of matplotlib plots generated during docs build
 setenv =
     MPLBACKEND=agg
     JUPYTER_PLATFORM_DIRS=1
+    ## devdeps:  PIP_EXTRA_INDEX_URL = 
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI
@@ -22,10 +29,12 @@ changedir = .tmp/{envname}
 
 # The following provides some specific pinnings for key packages
 deps =
-    pytest
-    ipyaladin
-    astroquery
-    sidecar
+    # NOTE: Add/remove as needed
+    devdeps: pytest>=0.0.dev0
+    devdeps: git+https://github.com/cds-astro/ipyaladin.git
+    devdeps: git+https://github.com/astropy/astroquery.git
+    devdeps: git+https://github.com/jupyter-widgets/jupyterlab-sidecar.git
+    devdeps: git+https://github.com/jupyter/jupyter.git
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
@@ -34,7 +43,7 @@ extras =
 commands =
     jupyter --paths
     pip freeze
-    pytest --pyargs mast_aladin_lite {posargs}
+    cov: pytest --pyargs mast_aladin_lite {toxinidir}/docs --cov mast_aladin_lite --cov-config={toxinidir}/pyproject.toml --ignore=mast_aladin_lite/qt.py {posargs}
 
 [testenv:linkcheck]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ extras =
 commands =
     jupyter --paths
     pip freeze
-    cov: pytest --pyargs mast_aladin_lite {toxinidir}/docs --cov mast_aladin_lite --cov-config={toxinidir}/pyproject.toml --ignore=mast_aladin_lite/qt.py {posargs}
+    cov: pytest --pyargs mast_aladin_lite {toxinidir}/docs --cov mast_aladin_lite --cov-config={toxinidir}/pyproject.toml
 
 [testenv:linkcheck]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -30,11 +30,14 @@ changedir = .tmp/{envname}
 # The following provides some specific pinnings for key packages
 deps =
     # NOTE: Add/remove as needed
-    devdeps: pytest>=0.0.dev0
-    devdeps: git+https://github.com/cds-astro/ipyaladin.git
+    devdeps: astropy>=0.0.dev0
+    devdeps: numpy>=0.0.dev0
     devdeps: git+https://github.com/astropy/astroquery.git
+    devdeps: git+https://github.com/astropy/regions.git
+    devdeps: git+https://github.com/cds-astro/ipyaladin.git
     devdeps: git+https://github.com/jupyter-widgets/jupyterlab-sidecar.git
     devdeps: git+https://github.com/jupyter/jupyter.git
+    devdeps: git+https://github.com/widgetti/solara.git
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
Expanding tox.ini and associated files for testing and incorporating requested dev repos to devdeps. Adding a sample test function.