### PR TITLE
CST-158 - Add MastAladin to top level of API

### DIFF
--- a/mast_aladin_lite/__init__.py
+++ b/mast_aladin_lite/__init__.py
@@ -1,1 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Top-level package for mast_aladin_lite."""
+
+# Top-level API as exposed to users.
+from .app import MastAladin  # noqa: F401

--- a/mast_aladin_lite/tests/test_example.py
+++ b/mast_aladin_lite/tests/test_example.py
@@ -1,5 +1,5 @@
 import pytest
-from mast_aladin_lite.app import MastAladin
+from mast_aladin_lite import MastAladin
 
 
 @pytest.fixture


### PR DESCRIPTION
This change allows `MastAladin` to be imported via:

```from mast_aladin_lite import MastAladin```

instead of needing the `.app` as in:

```from mast_aladin_lite.app import MastAladin```


The module's `__init__.py` has the change and the example test was updated to use the new import capability.