### PR TITLE
CST-149 add codecov to CI

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -69,4 +69,32 @@ jobs:
       run: python -m pip install --upgrade pip tox
     - name: Test/run with tox
       run: tox -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+    - name: Upload coverage to artifacts
+      if: "contains(matrix.toxenv, '-cov')"
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+      with:
+        name: coverage_${{ matrix.toxenv }}.xml
+        path: coverage.xml
+        if-no-files-found: error
 
+  upload-codecov:
+    needs: [ ci_tests ]
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest
+    name: Upload Coverage
+    steps:
+    - name: Download coverage artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        path: coverage
+        pattern: coverage_*
+        merge-multiple: true
+    - name: Upload report to Codecov
+      if: ${{ hashFiles('coverage/') != '' }}
+      uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # v5.3.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: coverage
+        fail_ci_if_error: true
+        verbose: true

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://codecov.io/gh/spacetelescope/mast-aladin-lite/branch/main/graph/badge.svg
+    :target: https://codecov.io/gh/spacetelescope/mast-aladin-lite
+
 # mast-aladin-lite
 
 While we are experimenting with Aladin Lite integration in MAST platforms, this repository can be used to contain:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist = 
-    py310-test-devdeps
-    py311-test-devdeps
+    py{310,311}-test-devdeps{,-cov}
     linkcheck
     codestyle
     pep517
@@ -47,6 +46,7 @@ commands =
     pip freeze
     !cov: pytest --pyargs mast_aladin_lite {toxinidir}/docs
     cov: pytest --pyargs mast_aladin_lite {toxinidir}/docs --cov mast_aladin_lite --cov-config={toxinidir}/pyproject.toml
+    cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:linkcheck]
 changedir = docs


### PR DESCRIPTION
adding codecov config in ci_workflows.yml and adding badge for codecov in README.rst

This was based on work in jdaviz (leveraging the same versioning tags as used in jdaviz), and Hatice assisted in setting up the token needed! Hoping to see the reports etc generate