### PR TITLE
CST-255 Cross-Widget Compatibility: set_viewport

### DIFF
--- a/mast_aladin_lite/aida.py
+++ b/mast_aladin_lite/aida.py
@@ -4,12 +4,10 @@ class AID:
     """
     Provides API for mast-aladin-lite to allow for parity with 
     jdaviz. This is to be used as a mixin within exisiting classes.
-    This is based on the Astro Image Display API (AIDA) formerly known
-    as the astrowidgets API.
+    This is based on the Astro Image Display API (AIDA).
 
     """
 
-    # __init__ the basics
     def __init__(self, mast_aladin):
         self.app = mast_aladin
 
@@ -27,9 +25,7 @@ class AID:
             Given coordinates are not provided as SkyCoord.
 
         """
-        # add check the coords are instance of sky coords, raise warning if not
-        # common APIs method only takes center on
-
+        
         if not isinstance(point, SkyCoord):
             raise NotImplementedError
         

--- a/mast_aladin_lite/aida.py
+++ b/mast_aladin_lite/aida.py
@@ -1,0 +1,37 @@
+from astropy.coordinates import SkyCoord
+
+class AID:
+    """
+    Provides API for mast-aladin-lite to allow for parity with 
+    jdaviz. This is to be used as a mixin within exisiting classes.
+    This is based on the Astro Image Display API (AIDA) formerly known
+    as the astrowidgets API.
+
+    """
+
+    # __init__ the basics
+    def __init__(self, mast_aladin):
+        self.app = mast_aladin
+
+    def center_on(self, point):
+        """
+        Centers the viewer on a particular point given as SkyCoords. 
+
+        Parameters
+        ----------
+        point : `~astropy.coordinates.SkyCoord`
+
+        Raises
+        ------
+        NotImplementedError
+            Given coordinates are not provided as SkyCoord.
+
+        """
+        # add check the coords are instance of sky coords, raise warning if not
+        # common APIs method only takes center on
+
+        if not isinstance(point, SkyCoord):
+            raise NotImplementedError
+        
+        self.app.target = point
+        

--- a/mast_aladin_lite/aida.py
+++ b/mast_aladin_lite/aida.py
@@ -36,7 +36,7 @@ class AID:
 
         if not isinstance(center, SkyCoord):
             raise TypeError(
-                "Invalid value for center. Center must be a SkyCoord or tuple of (X, Y)."
+                "`center` must be a SkyCoord object."
             )
 
         self.app.target = center

--- a/mast_aladin_lite/aida.py
+++ b/mast_aladin_lite/aida.py
@@ -1,8 +1,9 @@
 from astropy.coordinates import SkyCoord
 
+
 class AID:
     """
-    Provides API for mast-aladin-lite to allow for parity with 
+    Provides API for mast-aladin-lite to allow for parity with
     jdaviz. This is to be used as a mixin within exisiting classes.
     This is based on the Astro Image Display API (AIDA).
 
@@ -13,7 +14,7 @@ class AID:
 
     def center_on(self, point):
         """
-        Centers the viewer on a particular point given as SkyCoords. 
+        Centers the viewer on a particular point given as SkyCoords.
 
         Parameters
         ----------
@@ -25,9 +26,8 @@ class AID:
             Given coordinates are not provided as SkyCoord.
 
         """
-        
+
         if not isinstance(point, SkyCoord):
             raise NotImplementedError
-        
+
         self.app.target = point
-        

--- a/mast_aladin_lite/aida.py
+++ b/mast_aladin_lite/aida.py
@@ -5,29 +5,38 @@ class AID:
     """
     Provides API for mast-aladin-lite to allow for parity with
     jdaviz. This is to be used as a mixin within exisiting classes.
-    This is based on the Astro Image Display API (AIDA).
+    This is based on the Astro Image Display API (AIDA)[1]_.
+
+    References
+    ----------
+    .. [1] https://github.com/astropy/astro-image-display-api/
 
     """
 
     def __init__(self, mast_aladin):
         self.app = mast_aladin
 
-    def center_on(self, point):
+    def set_viewport(self, center):
         """
-        Centers the viewer on a particular point given as SkyCoords.
+        Sets the viewport based on provided parameters.
+        Presently, centers the viewer on a particular point, `center`,
+        given as `~astropy.coordinates.SkyCoord` objects.
 
         Parameters
         ----------
-        point : `~astropy.coordinates.SkyCoord`
+        center : `~astropy.coordinates.SkyCoord`
+            Center the viewer on this coordinate.
 
         Raises
         ------
-        NotImplementedError
+        TypeError
             Given coordinates are not provided as SkyCoord.
 
         """
 
-        if not isinstance(point, SkyCoord):
-            raise NotImplementedError
+        if not isinstance(center, SkyCoord):
+            raise TypeError(
+                "Invalid value for center. Center must be a SkyCoord or tuple of (X, Y)."
+            )
 
-        self.app.target = point
+        self.app.target = center

--- a/mast_aladin_lite/app.py
+++ b/mast_aladin_lite/app.py
@@ -7,4 +7,3 @@ class MastAladin(Aladin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.aid = AID(self)
-    pass

--- a/mast_aladin_lite/app.py
+++ b/mast_aladin_lite/app.py
@@ -7,5 +7,4 @@ class MastAladin(Aladin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.aid = AID(self)
-    
     pass

--- a/mast_aladin_lite/app.py
+++ b/mast_aladin_lite/app.py
@@ -1,5 +1,11 @@
 from ipyaladin import Aladin
+from mast_aladin_lite.aida import AID
 
 
 class MastAladin(Aladin):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.aid = AID(self)
+    
     pass

--- a/mast_aladin_lite/conftest.py
+++ b/mast_aladin_lite/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from mast_aladin_lite import MastAladin
+
+
+@pytest.fixture
+def MastAladin_helper():
+    return MastAladin()

--- a/mast_aladin_lite/tests/test_aida_example.py
+++ b/mast_aladin_lite/tests/test_aida_example.py
@@ -1,18 +1,13 @@
-import pytest
-from mast_aladin_lite import MastAladin
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 
 
-@pytest.fixture
-def MastAladin_helper():
-    return MastAladin()
-
 def assert_coordinate_close(coord1, coord2, atol=1 * u.arcsec):
     # check that two coordinates are within some separation tolerance
     separation = coord1.separation(coord2)
-    assert_quantity_allclose(separation, atol=atol)
+    assert_quantity_allclose(separation, desired=0*u.arcsec, atol=atol)
+
 
 def test_mast_aladin_has_aid(MastAladin_helper):
     assert hasattr(MastAladin_helper, 'aid')

--- a/mast_aladin_lite/tests/test_aida_example.py
+++ b/mast_aladin_lite/tests/test_aida_example.py
@@ -1,12 +1,18 @@
 import pytest
 from mast_aladin_lite import MastAladin
 from astropy.coordinates import SkyCoord
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
 
 
 @pytest.fixture
 def MastAladin_helper():
     return MastAladin()
 
+def assert_coordinate_close(coord1, coord2, atol=1 * u.arcsec):
+    # check that two coordinates are within some separation tolerance
+    separation = coord1.separation(coord2)
+    assert_quantity_allclose(separation, atol=atol)
 
 def test_mast_aladin_has_aid(MastAladin_helper):
     assert hasattr(MastAladin_helper, 'aid')
@@ -14,7 +20,10 @@ def test_mast_aladin_has_aid(MastAladin_helper):
 
 
 def test_mast_aladin_aid_set_viewport(MastAladin_helper):
-    assert MastAladin_helper.target == SkyCoord(0, 0, unit='deg')
+    # check that the default center coordinate is (0, 0) deg before
+    # we test the setter for center:
+    default_center = SkyCoord(0, 0, unit='deg')
+    assert_coordinate_close(MastAladin_helper.target, default_center)
     target_coords = SkyCoord(45, 45, unit='deg')
     MastAladin_helper.aid.set_viewport(center=target_coords)
-    assert MastAladin_helper.target == target_coords
+    assert_coordinate_close(MastAladin_helper.target, target_coords)

--- a/mast_aladin_lite/tests/test_aida_example.py
+++ b/mast_aladin_lite/tests/test_aida_example.py
@@ -1,0 +1,12 @@
+import pytest
+from mast_aladin_lite import MastAladin
+from astropy.coordinates import SkyCoord
+
+
+@pytest.fixture
+def MastAladin_helper():
+    return MastAladin()
+
+def test_mast_aladin_has_aid(MastAladin_helper):
+    assert hasattr(MastAladin_helper, 'aid')
+    assert callable(getattr(MastAladin_helper.aid, 'center_on', None))

--- a/mast_aladin_lite/tests/test_aida_example.py
+++ b/mast_aladin_lite/tests/test_aida_example.py
@@ -1,5 +1,6 @@
 import pytest
 from mast_aladin_lite import MastAladin
+from astropy.coordinates import SkyCoord
 
 
 @pytest.fixture
@@ -9,4 +10,11 @@ def MastAladin_helper():
 
 def test_mast_aladin_has_aid(MastAladin_helper):
     assert hasattr(MastAladin_helper, 'aid')
-    assert callable(getattr(MastAladin_helper.aid, 'center_on', None))
+    assert callable(getattr(MastAladin_helper.aid, 'set_viewport', None))
+
+
+def test_mast_aladin_aid_set_viewport(MastAladin_helper):
+    assert MastAladin_helper.target == SkyCoord(0, 0, unit='deg')
+    target_coords = SkyCoord(45, 45, unit='deg')
+    MastAladin_helper.aid.set_viewport(center=target_coords)
+    assert MastAladin_helper.target == target_coords

--- a/mast_aladin_lite/tests/test_aida_example.py
+++ b/mast_aladin_lite/tests/test_aida_example.py
@@ -1,11 +1,11 @@
 import pytest
 from mast_aladin_lite import MastAladin
-from astropy.coordinates import SkyCoord
 
 
 @pytest.fixture
 def MastAladin_helper():
     return MastAladin()
+
 
 def test_mast_aladin_has_aid(MastAladin_helper):
     assert hasattr(MastAladin_helper, 'aid')

--- a/notebooks/AIDA_mixin_center_on.ipynb
+++ b/notebooks/AIDA_mixin_center_on.ipynb
@@ -1,0 +1,189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "83ecc6e3-bfa1-45bc-a762-69e0a0ef4105",
+   "metadata": {},
+   "source": [
+    "## AIDA Mixin Demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb7ade2f-f073-411f-89ae-730094092eab",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eacf6bd7c8554201804abfb57ef41995",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "MastAladin()"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from mast_aladin_lite import MastAladin\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "\n",
+    "# Initializing with target loc set using ipyaladin method\n",
+    "mast_aladin = MastAladin(\n",
+    "    target= \"17 59 59.92 +65 54 00.3\",\n",
+    "    zoom = 2\n",
+    ")\n",
+    "mast_aladin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "65f31e74-c021-4595-b100-950d8d789871",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Adding a footprint for easy visual reference of functionality\n",
+    "mast_aladin.add_graphic_overlay_from_stcs(\"POLYGON ICRS 269.986903302 65.984279763 269.986696947 66.107243454 269.676617336 66.107210320 269.679951241 65.984356587\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9a592da-0b4a-4524-9923-4397590fb86b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Centering on 0,0, defines the var as point (matching jdaviz convention)\n",
+    "mast_aladin.aid.center_on(point=SkyCoord(0,0, unit=\"deg\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6937997-1030-476e-a34a-9074ef7015a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Recentering on corner of earlier polygon\n",
+    "mast_aladin.aid.center_on(SkyCoord(269.986903302, 65.984279763, unit=\"deg\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5210b2e-3c03-4e9d-877e-7d2bbcb54452",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NotImplementedError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[30], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# raises NotImplementedError since did not provide SkyCoord\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[43mmast_aladin\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43maid\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcenter_on\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpoint\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m0 0\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/repos/mast-aladin-lite/mast_aladin_lite/aida.py:31\u001b[0m, in \u001b[0;36mAID.center_on\u001b[0;34m(self, point)\u001b[0m\n\u001b[1;32m     27\u001b[0m \u001b[38;5;66;03m# add check the coords are instance of sky coords, raise warning if not\u001b[39;00m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;66;03m# common APIs method only takes center on\u001b[39;00m\n\u001b[1;32m     30\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(point, SkyCoord):\n\u001b[0;32m---> 31\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m\n\u001b[1;32m     33\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mapp\u001b[38;5;241m.\u001b[39mtarget \u001b[38;5;241m=\u001b[39m point\n",
+      "\u001b[0;31mNotImplementedError\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "# Raises NotImplementedError since did not provide SkyCoord\n",
+    "mast_aladin.aid.center_on(point=\"0 0\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "764042c6-8292-42e2-ab4e-a5604aae2b76",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NotImplementedError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[31], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# raises NotImplementedError since did not provide SkyCoord\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[43mmast_aladin\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43maid\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcenter_on\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m17 59 59.92 +65 54 00.3\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/repos/mast-aladin-lite/mast_aladin_lite/aida.py:31\u001b[0m, in \u001b[0;36mAID.center_on\u001b[0;34m(self, point)\u001b[0m\n\u001b[1;32m     27\u001b[0m \u001b[38;5;66;03m# add check the coords are instance of sky coords, raise warning if not\u001b[39;00m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;66;03m# common APIs method only takes center on\u001b[39;00m\n\u001b[1;32m     30\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(point, SkyCoord):\n\u001b[0;32m---> 31\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m\n\u001b[1;32m     33\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mapp\u001b[38;5;241m.\u001b[39mtarget \u001b[38;5;241m=\u001b[39m point\n",
+      "\u001b[0;31mNotImplementedError\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "# Raises NotImplementedError since did not provide SkyCoord\n",
+    "mast_aladin.aid.center_on(\"17 59 59.92 +65 54 00.3\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "94f53f5a-f948-4ba6-bd2e-09c130c9c230",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mmast_aladin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0maid\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcenter_on\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpoint\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Centers the viewer on a particular point. \n",
+       "\n",
+       "Parameters\n",
+       "----------\n",
+       "point : `~astropy.coordinates.SkyCoord`\n",
+       "\n",
+       "Raises\n",
+       "------\n",
+       "NotImplementedError\n",
+       "    Given coordinates are not provided as SkyCoord.\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/repos/mast-aladin-lite/mast_aladin_lite/aida.py\n",
+       "\u001b[0;31mType:\u001b[0m      method"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "mast_aladin.aid.center_on?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0918126e-bb6c-4f40-ac96-ddfab459bb79",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/AIDA_mixin_center_on.ipynb
+++ b/notebooks/AIDA_mixin_center_on.ipynb
@@ -13,23 +13,7 @@
    "execution_count": null,
    "id": "bb7ade2f-f073-411f-89ae-730094092eab",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eacf6bd7c8554201804abfb57ef41995",
-       "version_major": 2,
-       "version_minor": 1
-      },
-      "text/plain": [
-       "MastAladin()"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from mast_aladin_lite import MastAladin\n",
     "from astropy.coordinates import SkyCoord\n",
@@ -44,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "65f31e74-c021-4595-b100-950d8d789871",
    "metadata": {},
    "outputs": [],
@@ -80,20 +64,7 @@
    "execution_count": null,
    "id": "a5210b2e-3c03-4e9d-877e-7d2bbcb54452",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NotImplementedError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[30], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# raises NotImplementedError since did not provide SkyCoord\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[43mmast_aladin\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43maid\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcenter_on\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpoint\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m0 0\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/repos/mast-aladin-lite/mast_aladin_lite/aida.py:31\u001b[0m, in \u001b[0;36mAID.center_on\u001b[0;34m(self, point)\u001b[0m\n\u001b[1;32m     27\u001b[0m \u001b[38;5;66;03m# add check the coords are instance of sky coords, raise warning if not\u001b[39;00m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;66;03m# common APIs method only takes center on\u001b[39;00m\n\u001b[1;32m     30\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(point, SkyCoord):\n\u001b[0;32m---> 31\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m\n\u001b[1;32m     33\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mapp\u001b[38;5;241m.\u001b[39mtarget \u001b[38;5;241m=\u001b[39m point\n",
-      "\u001b[0;31mNotImplementedError\u001b[0m: "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Raises NotImplementedError since did not provide SkyCoord\n",
     "mast_aladin.aid.center_on(point=\"0 0\")"
@@ -104,20 +75,7 @@
    "execution_count": null,
    "id": "764042c6-8292-42e2-ab4e-a5604aae2b76",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NotImplementedError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[31], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# raises NotImplementedError since did not provide SkyCoord\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[43mmast_aladin\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43maid\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcenter_on\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m17 59 59.92 +65 54 00.3\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/repos/mast-aladin-lite/mast_aladin_lite/aida.py:31\u001b[0m, in \u001b[0;36mAID.center_on\u001b[0;34m(self, point)\u001b[0m\n\u001b[1;32m     27\u001b[0m \u001b[38;5;66;03m# add check the coords are instance of sky coords, raise warning if not\u001b[39;00m\n\u001b[1;32m     28\u001b[0m \u001b[38;5;66;03m# common APIs method only takes center on\u001b[39;00m\n\u001b[1;32m     30\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(point, SkyCoord):\n\u001b[0;32m---> 31\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m\n\u001b[1;32m     33\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mapp\u001b[38;5;241m.\u001b[39mtarget \u001b[38;5;241m=\u001b[39m point\n",
-      "\u001b[0;31mNotImplementedError\u001b[0m: "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Raises NotImplementedError since did not provide SkyCoord\n",
     "mast_aladin.aid.center_on(\"17 59 59.92 +65 54 00.3\")"
@@ -125,33 +83,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "94f53f5a-f948-4ba6-bd2e-09c130c9c230",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0mmast_aladin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0maid\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcenter_on\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpoint\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-       "\u001b[0;31mDocstring:\u001b[0m\n",
-       "Centers the viewer on a particular point. \n",
-       "\n",
-       "Parameters\n",
-       "----------\n",
-       "point : `~astropy.coordinates.SkyCoord`\n",
-       "\n",
-       "Raises\n",
-       "------\n",
-       "NotImplementedError\n",
-       "    Given coordinates are not provided as SkyCoord.\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/repos/mast-aladin-lite/mast_aladin_lite/aida.py\n",
-       "\u001b[0;31mType:\u001b[0m      method"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "mast_aladin.aid.center_on?"
    ]

--- a/notebooks/AIDA_mixin_set_viewport.ipynb
+++ b/notebooks/AIDA_mixin_set_viewport.ipynb
@@ -12,7 +12,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bb7ade2f-f073-411f-89ae-730094092eab",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "from mast_aladin_lite import MastAladin\n",
@@ -20,8 +22,8 @@
     "\n",
     "# Initializing with target loc set using ipyaladin method\n",
     "mast_aladin = MastAladin(\n",
-    "    target= \"17 59 59.92 +65 54 00.3\",\n",
-    "    zoom = 2\n",
+    "    target = \"269.999666,65.9000833\",\n",
+    "    zoom = 2,\n",
     ")\n",
     "mast_aladin"
    ]
@@ -34,7 +36,9 @@
    "outputs": [],
    "source": [
     "# Adding a footprint for easy visual reference of functionality\n",
-    "mast_aladin.add_graphic_overlay_from_stcs(\"POLYGON ICRS 269.986903302 65.984279763 269.986696947 66.107243454 269.676617336 66.107210320 269.679951241 65.984356587\")"
+    "# aladin-lite can load a footprint from an STC-S string like this one:\n",
+    "stcs_string = \"POLYGON ICRS 269.986903302 65.984279763 269.986696947 66.107243454 269.676617336 66.107210320 269.679951241 65.984356587\"\n",
+    "mast_aladin.add_graphic_overlay_from_stcs(stcs_string)"
    ]
   },
   {
@@ -44,8 +48,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Centering on 0,0, defines the var as point (matching jdaviz convention)\n",
-    "mast_aladin.aid.center_on(point=SkyCoord(0,0, unit=\"deg\"))"
+    "# Center the viewer on RA=0 deg, Dec=0 deg\n",
+    "mast_aladin.aid.set_viewport(center=SkyCoord(0,0, unit=\"deg\"))"
    ]
   },
   {
@@ -56,7 +60,7 @@
    "outputs": [],
    "source": [
     "# Recentering on corner of earlier polygon\n",
-    "mast_aladin.aid.center_on(SkyCoord(269.986903302, 65.984279763, unit=\"deg\"))"
+    "mast_aladin.aid.set_viewport(SkyCoord(269.986903302, 65.984279763, unit=\"deg\"))"
    ]
   },
   {
@@ -66,8 +70,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Raises NotImplementedError since did not provide SkyCoord\n",
-    "mast_aladin.aid.center_on(point=\"0 0\")"
+    "# Raises TypeError since did not provide SkyCoord\n",
+    "mast_aladin.aid.set_viewport(center=\"0 0\")"
    ]
   },
   {
@@ -77,8 +81,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Raises NotImplementedError since did not provide SkyCoord\n",
-    "mast_aladin.aid.center_on(\"17 59 59.92 +65 54 00.3\")"
+    "# Raises TypeError since did not provide SkyCoord\n",
+    "mast_aladin.aid.set_viewport(\"17 59 59.92 +65 54 00.3\")"
    ]
   },
   {
@@ -88,16 +92,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mast_aladin.aid.center_on?"
+    "mast_aladin.aid.set_viewport?"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0918126e-bb6c-4f40-ac96-ddfab459bb79",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This is the first step in adding in AIDA (Astro Image Display API) functionality for mast-aladin-lite, which will allow for users to leverage known functions. This introduces the center_on() method for mast-aladin-lite, which accepts SkyCoords for the viewer to center on. 

Contains a demo notebook for those interested in exploring and includes an initial example test. Future work will expand available functionality and methods.