### PR TITLE
add methods to sync orientation of imviz and aladin lite

### DIFF
--- a/mast_aladin_lite/app.py
+++ b/mast_aladin_lite/app.py
@@ -1,5 +1,81 @@
 from ipyaladin import Aladin
-
+from astropy.coordinates import Angle
+from jdaviz.utils import get_top_layer_index
+from jdaviz.core.user_api import ViewerUserApi
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+import numpy as np
 
 class MastAladin(Aladin):
-    pass
+    def set_orientation(self, viewer):
+        if isinstance(viewer, ViewerUserApi):
+            self.target, self.fov = self.get_imviz_orientation(viewer)
+        else:
+            print("Unsupported viewer type")
+
+    def get_imviz_orientation(self, imviz_viewer):
+        viewer = imviz_viewer._obj
+        sky_cen = viewer._get_center_skycoord()
+        imviz_fov = self._get_imviz_fov(viewer)
+
+        return sky_cen, imviz_fov
+
+    def set_imviz_orientation(self, imviz_viewer):
+        viewer = imviz_viewer._obj
+        viewer.set_limits(*self._get_aladin_limits(viewer))
+
+    def _get_imviz_fov(self, imviz_viewer):
+        """
+        Aladin lite defines the FOV as the width of the viewer in 
+        world coordinates. To calculate that for imviz, we need to 
+        get the world coordinates of the lower left and right pixels 
+        of the imviz viewer, and then calculate the separation between
+        those points.
+        """
+        x_min = imviz_viewer.state.x_min
+        x_max = imviz_viewer.state.x_max
+        y_min = imviz_viewer.state.y_min
+
+        wcs = imviz_viewer.state.reference_data.coords
+        lower_left = wcs.pixel_to_world(x_min, y_min)
+        lower_right = wcs.pixel_to_world(x_max, y_min)
+
+        return lower_left.separation(lower_right)
+
+    def _get_aladin_limits(self, imviz_viewer):
+        """
+        Calculate the pixel coordinate limits in the Imviz viewer corresponding 
+        to the Aladin Lite field of view.
+
+        Aladin Lite defines its center as the screen's center in WCS. In contrast, 
+        Imviz uses the center pixel to infer the corners. This function calculates 
+        the sky coordinates of the four corners of the Aladin view using spherical 
+        offsets, then converts them to pixel coordinates using the Imviz WCS.
+
+        Returns:
+            tuple: (x_min, x_max, y_min, y_max) pixel coordinates in Imviz WCS.
+        """
+        if self._fov_xy == {}:
+            raise ValueError("_fov_xy is not set due to a known issue in ipyaladin.")
+
+        if self.target is None:
+            raise ValueError("Target (SkyCoord) is not defined.")
+
+        wcs = imviz_viewer.state.reference_data.coords
+        half_fov_x = self._fov_xy["x"] * u.deg / 2
+        half_fov_y = self._fov_xy["y"] * u.deg / 2
+
+        offsets = [
+            (half_fov_x,  half_fov_y),
+            (-half_fov_x, half_fov_y),
+            (half_fov_x, -half_fov_y),
+            (-half_fov_x, -half_fov_y),
+        ]
+
+        corner_coords = [self.target.spherical_offsets_by(dx, dy) for dx, dy in offsets]
+        x, y = wcs.world_to_pixel(SkyCoord(corner_coords))
+
+        x_min, x_max = np.min(x), np.max(x)
+        y_min, y_max = np.min(y), np.max(y)
+
+        return x_min, x_max, y_min, y_max

--- a/notebooks/ImvizToAladinOrientationSync.ipynb
+++ b/notebooks/ImvizToAladinOrientationSync.ipynb
@@ -1,0 +1,145 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3970c041-1012-4a0d-8313-f7480cda8cd6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mast_aladin_lite.app import MastAladin\n",
+    "from jdaviz import Imviz\n",
+    "import warnings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "777b67f1-89e9-4730-af1a-45123f6bd7eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: Found cached file jw02727-o002_t062_nircam_clear-f090w_i2d.fits with expected size 715406400. [astroquery.query]\n",
+      "INFO: Found cached file jw02727-o002_t062_nircam_clear-f277w_i2d.fits with expected size 144060480. [astroquery.query]\n"
+     ]
+    }
+   ],
+   "source": [
+    "imviz = Imviz()\n",
+    "viewer = imviz.default_viewer\n",
+    "\n",
+    "filenames = [\n",
+    "    'jw02727-o002_t062_nircam_clear-f090w_i2d.fits',\n",
+    "    # 'jw02727-o002_t062_nircam_clear-f150w_i2d.fits',\n",
+    "    # 'jw02727-o002_t062_nircam_clear-f200w_i2d.fits',\n",
+    "    'jw02727-o002_t062_nircam_clear-f277w_i2d.fits',\n",
+    "    # 'jw02727-o002_t062_nircam_clear-f356w_i2d.fits',\n",
+    "    # 'jw02727-o002_t062_nircam_clear-f444w_i2d.fits'\n",
+    "]\n",
+    "\n",
+    "with warnings.catch_warnings(), imviz.batch_load():\n",
+    "    warnings.simplefilter('ignore')\n",
+    "    for fn in filenames:\n",
+    "        uri = f\"mast:JWST/product/{fn}\"\n",
+    "        imviz.load_data(uri, cache=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6da4ceb5-de48-4f4d-b731-005efaed6c53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MastAladin(target=\"Cartwheel Galaxy\", fov=.05, height=500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5f1061cd-e3bf-4a3f-9235-4da297e87f43",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a279e6a3ec0e4bf1862b5eb7494665ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Application(config='imviz', docs_link='https://jdaviz.readthedocs.io/en/latest/imviz/index.html', events=['cal…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "626cde98dc524ce682e57dc6dcf536e1",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "MastAladin()"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "imviz.show()\n",
+    "imviz.link_data(align_by='wcs')\n",
+    "imviz.plugins['Orientation'].set_north_up_east_left()\n",
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "db01b21c-dbb3-4203-8711-df6041ef4d04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a.set_imviz_orientation(viewer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "912bb531-7515-4e2d-ae03-7d012d4418b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a.set_orientation(viewer)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### What is changing?
add methods to sync orientation of imviz and mast aladin lite

### Why is this change needed?
required to support the interoperable layer between mast aladin lite and imviz

### How was this tested?
This change was tested through the included notebook. The following test cases were ran through manual verification 
- syncing imviz view to mast aladin lite
- syncing mast aladin lite view to imviz 
- syncing viewer when mast aladin is zoomed way out 
- syncing viewer when mast aladin is zoomed way in 

### Known bugs
There is a bug in ipyaladin where the `_fov_xy` traitlet is set to `{}` when the `fov` is changed. 