### PR TITLE
sync adapter demo implementation

### DIFF
--- a/mast_aladin_lite/adapters/__init__.py
+++ b/mast_aladin_lite/adapters/__init__.py
@@ -1,0 +1,4 @@
+from .mast_sync_manager import MastSyncManager
+from .viewer_sync_adapter import ViewerSyncAdapter
+from .imviz_sync_adapter import ImvizSyncAdapter
+from .aladin_sync_adapter import AladinSyncAdapter

--- a/mast_aladin_lite/adapters/aladin_sync_adapter.py
+++ b/mast_aladin_lite/adapters/aladin_sync_adapter.py
@@ -1,0 +1,58 @@
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+import numpy as np
+
+from .viewer_sync_adapter import ViewerSyncAdapter
+
+
+class AladinSyncAdapter(ViewerSyncAdapter):
+    def __init__(self, viewer):
+        # todo: assert the type of the viewer is ipyaladin
+        self.viewer = viewer
+
+    def get_center(self):
+        return self.viewer.target
+
+    def get_limits(self, wcs):
+        """
+        Aladin Lite defines its center as the screen's center in WCS. In contrast, 
+        Imviz uses the center pixel to infer the corners. This function calculates 
+        the sky coordinates of the four corners of the Aladin view using spherical 
+        offsets, then converts them to pixel coordinates using the Imviz WCS.
+
+        Returns:
+            tuple: (x_min, x_max, y_min, y_max) pixel coordinates in Imviz WCS.
+        """
+        if self.viewer._fov_xy == {}:
+            raise ValueError("_fov_xy is not set due to a known issue in ipyaladin.")
+
+        if self.viewer.target is None:
+            raise ValueError("Target (SkyCoord) is not defined.")
+
+        half_fov_x = self.viewer._fov_xy["x"] * u.deg / 2
+        half_fov_y = self.viewer._fov_xy["y"] * u.deg / 2
+
+        offsets = [
+            (half_fov_x,  half_fov_y),
+            (-half_fov_x, half_fov_y),
+            (half_fov_x, -half_fov_y),
+            (-half_fov_x, -half_fov_y),
+        ]
+
+        corner_coords = [self.viewer.target.spherical_offsets_by(dx, dy) for dx, dy in offsets]
+        x, y = wcs.world_to_pixel(SkyCoord(corner_coords))
+
+        x_min, x_max = np.min(x), np.max(x)
+        y_min, y_max = np.min(y), np.max(y)
+
+        return x_min, x_max, y_min, y_max
+
+    def get_fov(self):
+        return {
+            "x":  self.viewer._fov_xy["x"] * u.deg,
+            "y":  self.viewer._fov_xy["y"] * u.deg
+        }
+
+    def sync_to(self, sync_viewer):
+        self.viewer.target = sync_viewer.get_center()
+        self.viewer.fov = sync_viewer.get_fov()["x"].to_value()

--- a/mast_aladin_lite/adapters/imviz_sync_adapter.py
+++ b/mast_aladin_lite/adapters/imviz_sync_adapter.py
@@ -1,0 +1,37 @@
+from .viewer_sync_adapter import ViewerSyncAdapter
+
+
+class ImvizSyncAdapter(ViewerSyncAdapter):
+    def __init__(self, viewer):
+        # todo: assert the type of the viewer is jdaviz/imviz
+        self.viewer = viewer
+
+    def get_center(self):
+        return self.viewer._obj._get_center_skycoord()
+
+    def get_limits(self, wcs):
+        x_min, x_max = self.viewer._obj.state.x_min, self.viewer._obj.state.x_max
+        y_min, y_max = self.viewer._obj.state.y_min, self.viewer._obj.state.y_max
+
+        # todo: convert from the imviz wcs into the wcs passed to get_limits
+        return x_min, x_max, y_min, y_max
+
+    def get_fov(self):
+        x_min, x_max = self.viewer._obj.state.x_min, self.viewer._obj.state.x_max
+        y_min, y_max = self.viewer._obj.state.y_min, self.viewer._obj.state.y_max
+
+        lower_left = self._wcs.pixel_to_world(x_min, y_min)
+        lower_right = self._wcs.pixel_to_world(x_max, y_min)
+        upper_left = self._wcs.pixel_to_world(x_min, y_max)
+
+        return {
+            "x": lower_left.separation(lower_right),
+            "y": lower_left.separation(upper_left)
+        }
+
+    def sync_to(self, sync_viewer):
+        self.viewer._obj.set_limits(*sync_viewer.get_limits(self._wcs))
+
+    @property
+    def _wcs(self):
+        return self.viewer._obj.state.reference_data.coords

--- a/mast_aladin_lite/adapters/mast_sync_manager.py
+++ b/mast_aladin_lite/adapters/mast_sync_manager.py
@@ -1,0 +1,21 @@
+from .viewer_sync_adapter import ViewerSyncAdapter
+
+class MastSyncManager():
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._adapters = {}
+
+    def register_viewer(self, viewer_id, adapter: ViewerSyncAdapter):
+        self._adapters[viewer_id] = adapter
+
+    def get_adapter(self, viewer_id):
+        if viewer_id not in self._adapters:
+            raise TypeError(f"No registered ViewerSyncAdapter for viewer id {viewer_id}")
+        return self._adapters[viewer_id]
+
+    def sync_to(self, viewer_id):
+        sync_adapter = self.get_adapter(viewer_id)
+        for id, adapter in self._adapters.items():
+            if id != viewer_id:
+                adapter.sync_to(sync_adapter)
+

--- a/mast_aladin_lite/adapters/viewer_sync_adapter.py
+++ b/mast_aladin_lite/adapters/viewer_sync_adapter.py
@@ -1,0 +1,15 @@
+from astropy.coordinates import SkyCoord
+from astropy.wcs import WCS
+
+class ViewerSyncAdapter:
+    def get_center(self) -> SkyCoord:
+        raise NotImplementedError
+
+    def get_limits(self, wcs) -> WCS:
+        raise NotImplementedError
+
+    def get_fov(self) -> dict:
+        raise NotImplementedError
+
+    def sync_to(self, sync_viewer):
+        raise NotImplementedError

--- a/notebooks/AdapterExample.ipynb
+++ b/notebooks/AdapterExample.ipynb
@@ -1,0 +1,197 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "77228131-7882-4c80-9c95-5d9fa66dd496",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mast_aladin_lite.app import MastAladin\n",
+    "from mast_aladin_lite.adapters import MastSyncManager, ImvizSyncAdapter, AladinSyncAdapter\n",
+    "from jdaviz import Imviz\n",
+    "import warnings\n",
+    "from ipywidgets import Layout, Box, widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6e5e9cf5-fd47-4c44-9f8f-a16618e17e00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manager = MastSyncManager()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "afc680d3-a762-49a7-a8dc-d49d4f8e3fe6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:astroquery:Found cached file jw02727-o002_t062_nircam_clear-f090w_i2d.fits with expected size 715406400.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: Found cached file jw02727-o002_t062_nircam_clear-f090w_i2d.fits with expected size 715406400. [astroquery.query]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:astroquery:Found cached file jw02727-o002_t062_nircam_clear-f277w_i2d.fits with expected size 144060480.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: Found cached file jw02727-o002_t062_nircam_clear-f277w_i2d.fits with expected size 144060480. [astroquery.query]\n"
+     ]
+    }
+   ],
+   "source": [
+    "imviz = Imviz()\n",
+    "viewer = imviz.default_viewer\n",
+    "\n",
+    "filenames = [\n",
+    "    'jw02727-o002_t062_nircam_clear-f090w_i2d.fits',\n",
+    "    # 'jw02727-o002_t062_nircam_clear-f150w_i2d.fits',\n",
+    "    # 'jw02727-o002_t062_nircam_clear-f200w_i2d.fits',\n",
+    "    'jw02727-o002_t062_nircam_clear-f277w_i2d.fits',\n",
+    "    # 'jw02727-o002_t062_nircam_clear-f356w_i2d.fits',\n",
+    "    # 'jw02727-o002_t062_nircam_clear-f444w_i2d.fits'\n",
+    "]\n",
+    "\n",
+    "with warnings.catch_warnings(), imviz.batch_load():\n",
+    "    warnings.simplefilter('ignore')\n",
+    "    for fn in filenames:\n",
+    "        uri = f\"mast:JWST/product/{fn}\"\n",
+    "        imviz.load_data(uri, cache=True)\n",
+    "manager.register_viewer(\"imviz\", ImvizSyncAdapter(viewer))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ea5d7a00-d7ba-45a1-8b07-4d9784d6aa37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layout = Layout(width=\"100%\")\n",
+    "a = MastAladin(target=\"Cartwheel Galaxy\", layout=layout, fov=.05, height=500)\n",
+    "manager.register_viewer(\"aladin-a\", AladinSyncAdapter(a))\n",
+    "\n",
+    "b = MastAladin(target=\"Cartwheel Galaxy\", layout=layout, survey=\"P/DSS2/red\", fov=.05, height=500)\n",
+    "\n",
+    "box_layout = Layout(\n",
+    "    display=\"flex\", flex_flow=\"row\", align_items=\"stretch\", border=\"solid\", width=\"100%\"\n",
+    ")\n",
+    "box = Box(children=[a,b], layout=box_layout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "3d605b48-94c9-426c-a088-f14c7d79b3a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manager.register_viewer(\"imviz\", ImvizSyncAdapter(viewer))\n",
+    "manager.register_viewer(\"aladin-a\", AladinSyncAdapter(a))\n",
+    "manager.register_viewer(\"aladin-b\", AladinSyncAdapter(b))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "edc4a986-a620-4d28-98b5-9781395974bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6a9bec8ec68a42148fe721f56cff427a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Application(config='imviz', docs_link='https://jdaviz.readthedocs.io/en/latest/imviz/index.html', events=['cal…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6f337e44e90340da85988bd0c207e7f1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Box(children=(MastAladin(layout=Layout(width='100%')), MastAladin(layout=Layout(width='100%'), survey='P/DSS2/…"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "imviz.show()\n",
+    "imviz.link_data(align_by='wcs')\n",
+    "imviz.plugins['Orientation'].set_north_up_east_left()\n",
+    "box"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "a531fff5-35f7-4ee7-8c85-9240a576a81e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manager.sync_to(\"aladin-a\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "636d5035-552a-4b1f-aac0-496215d41adc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### What is Changing?
This PR introduces a demo implementation of a sync adapter system for coordinating views between MAST Aladin Lite and Imviz.

### Why is This Change Needed?

This change establishes a scalable architecture for synchronizing multiple astronomical viewers. It provides a generalized way to link viewers like MAST Aladin Lite and Imviz, with a design that can easily accommodate future viewers and functionality.

A new class, `MastSyncManager`, tracks all configured viewers and exposes a `sync_to` method that synchronizes all registered viewers to the view of a designated source viewer.

The `ViewerSyncAdapter` interface abstracts the synchronization logic for individual viewers. The key method, `sync_to`, accepts another `ViewerSyncAdapter` and adapts its own state to match the provided viewer's view, using only the subset of interface data it supports.

For example:
- MAST Aladin Lite syncs by setting its target and fov.
- Imviz syncs by updating the x and y axis limits directly.

This interface-based design allows for clean support of different viewer types.

### How Was This Tested?

Testing was conducted using the included Jupyter notebook with the following manually verified test cases:
    Syncing Imviz to match MAST Aladin Lite
    Syncing MAST Aladin Lite to match Imviz
    Syncing views when MAST Aladin Lite is zoomed very far out
    Syncing views when MAST Aladin Lite is zoomed very far in
    Syncing one MAST Aladin Lite viewer to another

### Known Issues
There is a known bug in ipyaladin where updating the `fov` results in the `_fov_xy` traitlet being set to an empty dictionary, `{}`. We should create an issue in ipyaladin to address this down the line