### PR TITLE
CST-264 Cross-Widget Compatibility: get_viewport

### DIFF
--- a/mast_aladin_lite/aida.py
+++ b/mast_aladin_lite/aida.py
@@ -79,8 +79,9 @@ class AID:
 
         Raises
         ------
-        TypeError
-            Given coordinates are not provided as SkyCoord.
+        NotImplementedError
+            Given `sky_or_pixel` is not "sky" or `None`.
+            Given `image_label` is not `None`.
 
         """
 

--- a/mast_aladin_lite/aida.py
+++ b/mast_aladin_lite/aida.py
@@ -73,6 +73,9 @@ class AID:
                 Center the viewer on this coordinate.
             - fov : `~astropy.coordinates.Angle`
                 An object representing the field of view.
+            - image_label: None
+                A string representing the label of the image, always `None`
+                for aladin-lite since it has one 'image" per viewer.
 
         Raises
         ------
@@ -97,5 +100,6 @@ class AID:
 
         viewport_state["center"] = self.app.target
         viewport_state["fov"] = self.app.fov
+        viewport_state["image_label"] = None
 
         return viewport_state

--- a/mast_aladin_lite/aida.py
+++ b/mast_aladin_lite/aida.py
@@ -1,5 +1,4 @@
 from astropy.coordinates import SkyCoord
-from typing import Any
 
 
 class AID:
@@ -43,27 +42,20 @@ class AID:
         self.app.target = center
 
     def get_viewport(
-        self,
-        sky_or_pixel: str | None = "sky",
-        image_label: str | None = None
-    ) -> dict[str, Any]:
+        self, sky_or_pixel="sky", image_label=None
+    ):
         """
-        Gets the current viewport of the viewer.
-        Presently, returns a dictionary containing the viewer's `center`,
-        given as `~astropy.coordinates.SkyCoord` objects, and the viewer's
-        `fov`, given as an `~astropy.units.Angle` object.
+        Gets the viewport center and field of view.
 
         Parameters
         ----------
         sky_or_pixel : str, optional
-            If 'sky', the center will be returned as a `SkyCoord` object.
-            If `None`, the default behavior is to return the center as a `SkyCoord`.
-            Any other values will raise the error that "aladin-lite is a HiPS viewer
-            without a concept of pixels"
+            If `"sky"` or `None`, the viewport center and field of view will be returned
+            in world coordinates. `"pixel"` is not supported for HiPS viewers.
         image_label : str, optional
-            The label of the image to get the viewport for. If a value is provided,
-            the error will be raised that "aladin-lite only shows one 'image' per
-            viewer, and does not need the concept of labels”.
+            `image_label` is a required argument for ``AID`` API compatibility,
+            but it is not relevant for HiPS browsers like aladin-lite. If not
+            `None`, an error will be raised.
 
         Returns
         -------
@@ -75,7 +67,7 @@ class AID:
                 An object representing the field of view.
             - image_label: None
                 A string representing the label of the image, always `None`
-                for aladin-lite since it has one 'image" per viewer.
+                for aladin-lite.
 
         Raises
         ------
@@ -84,8 +76,6 @@ class AID:
             Given `image_label` is not `None`.
 
         """
-
-        viewport_state = {}
 
         if sky_or_pixel != "sky" and sky_or_pixel is not None:
             raise NotImplementedError(
@@ -99,8 +89,10 @@ class AID:
                 "the concept of labels. `image_label` must be set to `None`."
             )
 
-        viewport_state["center"] = self.app.target
-        viewport_state["fov"] = self.app.fov
-        viewport_state["image_label"] = None
+        viewport_state = dict(
+            center=self.app.target,
+            fov=self.app.fov,
+            image_label=None
+        )
 
         return viewport_state

--- a/mast_aladin_lite/aida.py
+++ b/mast_aladin_lite/aida.py
@@ -1,4 +1,5 @@
 from astropy.coordinates import SkyCoord
+from typing import Any
 
 
 class AID:
@@ -40,3 +41,56 @@ class AID:
             )
 
         self.app.target = center
+
+    def get_viewport(
+            self, sky_or_pixel: str | None = "sky", image_label: str | None = None) -> dict[str, Any]:
+        """
+        Gets the current viewport of the viewer.
+        Presently, returns a dictionary containing the viewer's `center`,
+        given as `~astropy.coordinates.SkyCoord` objects, and the viewer's
+        `fov`, given as an `~astropy.units.Angle` object.
+
+        Parameters
+        ----------
+        sky_or_pixel : str, optional
+            If 'sky', the center will be returned as a `SkyCoord` object.
+            If `None`, the default behavior is to return the center as a `SkyCoord`.
+            Any other values will raise the error that "aladin-lite is a HiPS viewer
+            without a concept of pixels"
+        image_label : str, optional
+            The label of the image to get the viewport for. If a value is provided,
+            the error will be raised that "aladin-lite only shows one 'image' per
+            viewer, and does not need the concept of labels”.
+
+        Returns
+        -------
+        dict
+            A dictionary containing:
+            - center : `~astropy.coordinates.SkyCoord`
+                Center the viewer on this coordinate.
+            - fov : `~astropy.coordinates.Angle`
+                An object representing the field of view.
+
+        Raises
+        ------
+        TypeError
+            Given coordinates are not provided as SkyCoord.
+
+        """
+
+        viewport_state = {}
+
+        if sky_or_pixel != "sky" and sky_or_pixel is not None:
+            raise NotImplementedError(
+                "aladin-lite is a HiPS viewer without a concept of pixels. `sky_or_pixel` must be set to 'sky' or `None`"
+            )
+
+        if image_label is not None:
+            raise NotImplementedError(
+                "aladin-lite only shows one 'image' per viewer, and does not need the concept of labels. `image_label` must be set to `None`."
+            )
+
+        viewport_state["center"] = self.app.target
+        viewport_state["fov"] = self.app.fov
+
+        return viewport_state

--- a/mast_aladin_lite/aida.py
+++ b/mast_aladin_lite/aida.py
@@ -43,7 +43,10 @@ class AID:
         self.app.target = center
 
     def get_viewport(
-            self, sky_or_pixel: str | None = "sky", image_label: str | None = None) -> dict[str, Any]:
+        self,
+        sky_or_pixel: str | None = "sky",
+        image_label: str | None = None
+    ) -> dict[str, Any]:
         """
         Gets the current viewport of the viewer.
         Presently, returns a dictionary containing the viewer's `center`,
@@ -82,12 +85,14 @@ class AID:
 
         if sky_or_pixel != "sky" and sky_or_pixel is not None:
             raise NotImplementedError(
-                "aladin-lite is a HiPS viewer without a concept of pixels. `sky_or_pixel` must be set to 'sky' or `None`"
+                "aladin-lite is a HiPS viewer without a concept of pixels."
+                "`sky_or_pixel` must be set to 'sky' or `None`"
             )
 
         if image_label is not None:
             raise NotImplementedError(
-                "aladin-lite only shows one 'image' per viewer, and does not need the concept of labels. `image_label` must be set to `None`."
+                "aladin-lite only shows one 'image' per viewer, and does not need"
+                "the concept of labels. `image_label` must be set to `None`."
             )
 
         viewport_state["center"] = self.app.target

--- a/mast_aladin_lite/tests/test_aida_example.py
+++ b/mast_aladin_lite/tests/test_aida_example.py
@@ -9,14 +9,17 @@ def assert_coordinate_close(coord1, coord2, atol=1 * u.arcsec):
     separation = coord1.separation(coord2)
     assert_quantity_allclose(separation, desired=0*u.arcsec, atol=atol)
 
+
 def assert_angle_close(angle1, angle2, atol=1 * u.arcsec):
     # check that two angles are within some separation tolerance
     difference = np.abs(angle1 - angle2)
     assert_quantity_allclose(difference, desired=0*u.arcsec, atol=atol)
 
+
 def test_mast_aladin_has_aid(MastAladin_helper):
     assert hasattr(MastAladin_helper, 'aid')
     assert callable(getattr(MastAladin_helper.aid, 'set_viewport', None))
+
 
 def test_mast_aladin_aid_set_viewport(MastAladin_helper):
     # check that the default center coordinate is (0, 0) deg before
@@ -27,20 +30,21 @@ def test_mast_aladin_aid_set_viewport(MastAladin_helper):
     MastAladin_helper.aid.set_viewport(center=target_coords)
     assert_coordinate_close(MastAladin_helper.target, target_coords)
 
+
 def test_mast_aladin_aid_get_viewport(MastAladin_helper):
     # check that the default center coordinate is (0, 0) deg and
     # the default fov is 60.0 deg
     default_center = SkyCoord(0, 0, unit='deg')
     default_viewport = MastAladin_helper.aid.get_viewport()
     assert_coordinate_close(default_viewport["center"], default_center)
-    assert_angle_close(Angle(60, u.deg),default_viewport["fov"])
-    
+    assert_angle_close(Angle(60, u.deg), default_viewport["fov"])
+
+
 def test_mast_aladin_aid_get_and_set_viewport_roundtrip(MastAladin_helper):
-    # check that performing a round trip of getting and setting the 
+    # check that performing a round trip of getting and setting the
     # viewport results in the original state
 
     # get default settings
-    default_center = SkyCoord(0, 0, unit='deg')
     default_viewport = MastAladin_helper.aid.get_viewport()
 
     # change viewport settings
@@ -50,12 +54,12 @@ def test_mast_aladin_aid_get_and_set_viewport_roundtrip(MastAladin_helper):
     # check new viewport settings
     midpoint_viewport = MastAladin_helper.aid.get_viewport()
     assert_coordinate_close(midpoint_viewport["center"], target_coords)
-    assert_angle_close(Angle(60, u.deg),midpoint_viewport["fov"])
+    assert_angle_close(Angle(60, u.deg), midpoint_viewport["fov"])
 
     # change viewport settings back to default
-    MastAladin_helper.aid.set_viewport(center=default_center)
+    MastAladin_helper.aid.set_viewport(center=default_viewport["center"])
 
     # check final viewport settings
     final_viewport = MastAladin_helper.aid.get_viewport()
-    assert_coordinate_close(final_viewport["center"], default_center)
-    assert_angle_close(Angle(60, u.deg),final_viewport["fov"])
+    assert_coordinate_close(final_viewport["center"], default_viewport["center"])
+    assert_angle_close(default_viewport["fov"], final_viewport["fov"])

--- a/mast_aladin_lite/tests/test_aida_example.py
+++ b/mast_aladin_lite/tests/test_aida_example.py
@@ -1,7 +1,6 @@
 from astropy.coordinates import SkyCoord, Angle
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
-import numpy as np
 
 
 def assert_coordinate_close(coord1, coord2, atol=1 * u.arcsec):
@@ -12,7 +11,7 @@ def assert_coordinate_close(coord1, coord2, atol=1 * u.arcsec):
 
 def assert_angle_close(angle1, angle2, atol=1 * u.arcsec):
     # check that two angles are within some separation tolerance
-    difference = np.abs(angle1 - angle2)
+    difference = abs(angle1 - angle2)
     assert_quantity_allclose(difference, desired=0*u.arcsec, atol=atol)
 
 

--- a/mast_aladin_lite/tests/test_aida_example.py
+++ b/mast_aladin_lite/tests/test_aida_example.py
@@ -32,12 +32,13 @@ def test_mast_aladin_aid_set_viewport(MastAladin_helper):
 
 
 def test_mast_aladin_aid_get_viewport(MastAladin_helper):
-    # check that the default center coordinate is (0, 0) deg and
-    # the default fov is 60.0 deg
+    # check that the default center coordinate is (0, 0) deg,
+    # the default fov is 60.0 deg, and the image_label is None
     default_center = SkyCoord(0, 0, unit='deg')
     default_viewport = MastAladin_helper.aid.get_viewport()
     assert_coordinate_close(default_viewport["center"], default_center)
     assert_angle_close(Angle(60, u.deg), default_viewport["fov"])
+    assert default_viewport["image_label"] is None
 
 
 def test_mast_aladin_aid_get_and_set_viewport_roundtrip(MastAladin_helper):
@@ -55,6 +56,7 @@ def test_mast_aladin_aid_get_and_set_viewport_roundtrip(MastAladin_helper):
     midpoint_viewport = MastAladin_helper.aid.get_viewport()
     assert_coordinate_close(midpoint_viewport["center"], target_coords)
     assert_angle_close(Angle(60, u.deg), midpoint_viewport["fov"])
+    assert midpoint_viewport["image_label"] is None
 
     # change viewport settings back to default
     MastAladin_helper.aid.set_viewport(center=default_viewport["center"])
@@ -63,3 +65,4 @@ def test_mast_aladin_aid_get_and_set_viewport_roundtrip(MastAladin_helper):
     final_viewport = MastAladin_helper.aid.get_viewport()
     assert_coordinate_close(final_viewport["center"], default_viewport["center"])
     assert_angle_close(default_viewport["fov"], final_viewport["fov"])
+    assert final_viewport["image_label"] is None

--- a/mast_aladin_lite/tests/test_aida_example.py
+++ b/mast_aladin_lite/tests/test_aida_example.py
@@ -1,6 +1,7 @@
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, Angle
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
+import numpy as np
 
 
 def assert_coordinate_close(coord1, coord2, atol=1 * u.arcsec):
@@ -8,11 +9,14 @@ def assert_coordinate_close(coord1, coord2, atol=1 * u.arcsec):
     separation = coord1.separation(coord2)
     assert_quantity_allclose(separation, desired=0*u.arcsec, atol=atol)
 
+def assert_angle_close(angle1, angle2, atol=1 * u.arcsec):
+    # check that two angles are within some separation tolerance
+    difference = np.abs(angle1 - angle2)
+    assert_quantity_allclose(difference, desired=0*u.arcsec, atol=atol)
 
 def test_mast_aladin_has_aid(MastAladin_helper):
     assert hasattr(MastAladin_helper, 'aid')
     assert callable(getattr(MastAladin_helper.aid, 'set_viewport', None))
-
 
 def test_mast_aladin_aid_set_viewport(MastAladin_helper):
     # check that the default center coordinate is (0, 0) deg before
@@ -22,3 +26,36 @@ def test_mast_aladin_aid_set_viewport(MastAladin_helper):
     target_coords = SkyCoord(45, 45, unit='deg')
     MastAladin_helper.aid.set_viewport(center=target_coords)
     assert_coordinate_close(MastAladin_helper.target, target_coords)
+
+def test_mast_aladin_aid_get_viewport(MastAladin_helper):
+    # check that the default center coordinate is (0, 0) deg and
+    # the default fov is 60.0 deg
+    default_center = SkyCoord(0, 0, unit='deg')
+    default_viewport = MastAladin_helper.aid.get_viewport()
+    assert_coordinate_close(default_viewport["center"], default_center)
+    assert_angle_close(Angle(60, u.deg),default_viewport["fov"])
+    
+def test_mast_aladin_aid_get_and_set_viewport_roundtrip(MastAladin_helper):
+    # check that performing a round trip of getting and setting the 
+    # viewport results in the original state
+
+    # get default settings
+    default_center = SkyCoord(0, 0, unit='deg')
+    default_viewport = MastAladin_helper.aid.get_viewport()
+
+    # change viewport settings
+    target_coords = SkyCoord(45, 45, unit='deg')
+    MastAladin_helper.aid.set_viewport(center=target_coords)
+
+    # check new viewport settings
+    midpoint_viewport = MastAladin_helper.aid.get_viewport()
+    assert_coordinate_close(midpoint_viewport["center"], target_coords)
+    assert_angle_close(Angle(60, u.deg),midpoint_viewport["fov"])
+
+    # change viewport settings back to default
+    MastAladin_helper.aid.set_viewport(center=default_center)
+
+    # check final viewport settings
+    final_viewport = MastAladin_helper.aid.get_viewport()
+    assert_coordinate_close(final_viewport["center"], default_center)
+    assert_angle_close(Angle(60, u.deg),final_viewport["fov"])

--- a/notebooks/AIDA_mixin_get_viewport.ipynb
+++ b/notebooks/AIDA_mixin_get_viewport.ipynb
@@ -1,0 +1,143 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "83ecc6e3-bfa1-45bc-a762-69e0a0ef4105",
+   "metadata": {},
+   "source": [
+    "## AIDA Mixin Demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb7ade2f-f073-411f-89ae-730094092eab",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from mast_aladin_lite import MastAladin\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "\n",
+    "# Initializing with target loc set using ipyaladin method\n",
+    "mast_aladin = MastAladin(\n",
+    "    target = \"269.999666,65.9000833\",\n",
+    "    zoom = 2,\n",
+    ")\n",
+    "mast_aladin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65f31e74-c021-4595-b100-950d8d789871",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Adding a footprint for easy visual reference of functionality\n",
+    "# aladin-lite can load a footprint from an STC-S string like this one:\n",
+    "stcs_string = \"POLYGON ICRS 269.986903302 65.984279763 269.986696947 66.107243454 269.676617336 66.107210320 269.679951241 65.984356587\"\n",
+    "mast_aladin.add_graphic_overlay_from_stcs(stcs_string)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7859ba85-5e06-436e-ba4a-ca2fa122be3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Recentering on corner of earlier polygon\n",
+    "mast_aladin.aid.set_viewport(SkyCoord(269.986903302, 65.984279763, unit=\"deg\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f22cc7a-78b0-4d64-adff-3738d5e0bdc1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get this viewport state for later\n",
+    "viewport_state = mast_aladin.aid.get_viewport()\n",
+    "viewport_state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70e93217-6e72-4fa0-8562-a5bd43c911db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Center the viewer on RA=0 deg, Dec=0 deg\n",
+    "mast_aladin.aid.set_viewport(center=SkyCoord(0,0, unit=\"deg\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e88af4a3-0232-47a9-81a5-18396f2415e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now, let's return the viewport to the state that centers on the corner of the eartlier polygon\n",
+    "mast_aladin.aid.set_viewport(viewport_state[\"center\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5210b2e-3c03-4e9d-877e-7d2bbcb54452",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Raises NotImplementedError since aladin-lite has no concept of pixels\n",
+    "mast_aladin.aid.get_viewport(sky_or_pixel=\"pixel\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "764042c6-8292-42e2-ab4e-a5604aae2b76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Raises NotImplementedError since aladin-lite only shows one image and has no concept of labels\n",
+    "mast_aladin.aid.get_viewport(image_label = \"image1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94f53f5a-f948-4ba6-bd2e-09c130c9c230",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mast_aladin.aid.get_viewport?"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Continuing the work done in #25 to add in AIDA (Astro Image Display API) functionality for mast-aladin-lite. This introduces the get_viewport functionality to complement the set_viewport functionality that has been implemented thus far.
It accepts `sky_or_pixel` and `image_label` arguments and returns a dictionary with `center`, `fov`, and `image_label`. 

This contains a demo notebook for those interested in exploring, which shows the round-trip-traversal of getting and setting viewports. It also includes initial example tests of getting (including a round-trip).