### PR TITLE
Adding method to get 'current app', renaming app fixture

### DIFF
--- a/mast_aladin_lite/app.py
+++ b/mast_aladin_lite/app.py
@@ -2,8 +2,26 @@ from ipyaladin import Aladin
 from mast_aladin_lite.aida import AID
 
 
+# store reference to the latest instantiation:
+_latest_instantiated_app = None
+
+
 class MastAladin(Aladin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.aid = AID(self)
+
+        global _latest_instantiated_app
+        _latest_instantiated_app = self
+
+
+def gca():
+    """
+    Get the current mast-aladin-lite application instance.
+
+    Returns
+    -------
+    MastAladin
+    """
+    return _latest_instantiated_app

--- a/mast_aladin_lite/conftest.py
+++ b/mast_aladin_lite/conftest.py
@@ -3,5 +3,5 @@ from mast_aladin_lite import MastAladin
 
 
 @pytest.fixture
-def MastAladin_helper():
+def MastAladin_app():
     return MastAladin()

--- a/mast_aladin_lite/tests/test_aida_example.py
+++ b/mast_aladin_lite/tests/test_aida_example.py
@@ -15,53 +15,53 @@ def assert_angle_close(angle1, angle2, atol=1 * u.arcsec):
     assert_quantity_allclose(difference, desired=0*u.arcsec, atol=atol)
 
 
-def test_mast_aladin_has_aid(MastAladin_helper):
-    assert hasattr(MastAladin_helper, 'aid')
-    assert callable(getattr(MastAladin_helper.aid, 'set_viewport', None))
+def test_mast_aladin_has_aid(MastAladin_app):
+    assert hasattr(MastAladin_app, 'aid')
+    assert callable(getattr(MastAladin_app.aid, 'set_viewport', None))
 
 
-def test_mast_aladin_aid_set_viewport(MastAladin_helper):
+def test_mast_aladin_aid_set_viewport(MastAladin_app):
     # check that the default center coordinate is (0, 0) deg before
     # we test the setter for center:
     default_center = SkyCoord(0, 0, unit='deg')
-    assert_coordinate_close(MastAladin_helper.target, default_center)
+    assert_coordinate_close(MastAladin_app.target, default_center)
     target_coords = SkyCoord(45, 45, unit='deg')
-    MastAladin_helper.aid.set_viewport(center=target_coords)
-    assert_coordinate_close(MastAladin_helper.target, target_coords)
+    MastAladin_app.aid.set_viewport(center=target_coords)
+    assert_coordinate_close(MastAladin_app.target, target_coords)
 
 
-def test_mast_aladin_aid_get_viewport(MastAladin_helper):
+def test_mast_aladin_aid_get_viewport(MastAladin_app):
     # check that the default center coordinate is (0, 0) deg,
     # the default fov is 60.0 deg, and the image_label is None
     default_center = SkyCoord(0, 0, unit='deg')
-    default_viewport = MastAladin_helper.aid.get_viewport()
+    default_viewport = MastAladin_app.aid.get_viewport()
     assert_coordinate_close(default_viewport["center"], default_center)
     assert_angle_close(Angle(60, u.deg), default_viewport["fov"])
     assert default_viewport["image_label"] is None
 
 
-def test_mast_aladin_aid_get_and_set_viewport_roundtrip(MastAladin_helper):
+def test_mast_aladin_aid_get_and_set_viewport_roundtrip(MastAladin_app):
     # check that performing a round trip of getting and setting the
     # viewport results in the original state
 
     # get default settings
-    default_viewport = MastAladin_helper.aid.get_viewport()
+    default_viewport = MastAladin_app.aid.get_viewport()
 
     # change viewport settings
     target_coords = SkyCoord(45, 45, unit='deg')
-    MastAladin_helper.aid.set_viewport(center=target_coords)
+    MastAladin_app.aid.set_viewport(center=target_coords)
 
     # check new viewport settings
-    midpoint_viewport = MastAladin_helper.aid.get_viewport()
+    midpoint_viewport = MastAladin_app.aid.get_viewport()
     assert_coordinate_close(midpoint_viewport["center"], target_coords)
     assert_angle_close(Angle(60, u.deg), midpoint_viewport["fov"])
     assert midpoint_viewport["image_label"] is None
 
     # change viewport settings back to default
-    MastAladin_helper.aid.set_viewport(center=default_viewport["center"])
+    MastAladin_app.aid.set_viewport(center=default_viewport["center"])
 
     # check final viewport settings
-    final_viewport = MastAladin_helper.aid.get_viewport()
+    final_viewport = MastAladin_app.aid.get_viewport()
     assert_coordinate_close(final_viewport["center"], default_viewport["center"])
     assert_angle_close(default_viewport["fov"], final_viewport["fov"])
     assert final_viewport["image_label"] is None

--- a/mast_aladin_lite/tests/test_app.py
+++ b/mast_aladin_lite/tests/test_app.py
@@ -1,0 +1,12 @@
+from mast_aladin_lite.app import MastAladin, gca
+
+
+def test_current_app(MastAladin_app):
+    # MastAladin_app should be the current instance of the app
+    assert gca() == MastAladin_app
+
+    # create new app instance
+    instance2 = MastAladin()
+
+    # gca should refer to the newly instantiated app:
+    assert gca() == instance2

--- a/mast_aladin_lite/tests/test_example.py
+++ b/mast_aladin_lite/tests/test_example.py
@@ -1,5 +1,5 @@
 from mast_aladin_lite import MastAladin
 
 
-def test_instance_creation(MastAladin_helper):
-    assert isinstance(MastAladin_helper, MastAladin)
+def test_instance_creation(MastAladin_app):
+    assert isinstance(MastAladin_app, MastAladin)


### PR DESCRIPTION
This PR adds a `gca()` method to "get the current app", inspired by matplotlib's `plt.gca()` and `plt.gcf()` methods, and followed by jdaviz in https://github.com/spacetelescope/jdaviz/pull/3632 (plus the temporary workaround for Cobalt's use in https://github.com/spacetelescope/jdaviz/pull/3649).

We will soon use this feature to find the instance of `MastAladin` from within `jdaviz`, and vice versa.

I've also changed the name of the test fixture `MastAladin_helper` to `MastAladin_app`. The "helper" was a holdover from the jdaviz term for the "app" that users interact with. jdaviz will be moving towards using "app" rather than "helper", so we can make the helper replacement in mast-aladin-lite too.