### PR TITLE
fix codecov file path issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     #jupyter --paths
     pip freeze
     !cov: pytest --pyargs mast_aladin_lite {toxinidir}/docs
-    cov: pytest --pyargs mast_aladin_lite {toxinidir}/docs --cov mast_aladin_lite --cov-config={toxinidir}/pyproject.toml
+    cov: pytest --pyargs mast_aladin_lite {toxinidir}/docs --cov mast_aladin_lite --cov-config={toxinidir}/pyproject.toml --cov-source=mast_aladin_lite
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:linkcheck]


### PR DESCRIPTION
### What is changing?
fix codecov file path to use repo-relative file paths instead of the weird file paths generated by pytest 

### Why is this change needed?
We have been receiving the following [code coverage errors](https://app.codecov.io/gh/spacetelescope/mast-aladin-lite/commit/141405b450f5a2cb69a9cfc532dc601cddf4a446)
> Unusable report due to issues such as source code unavailability, path mismatch, empty report, or incorrect data format. Please visit our [troubleshooting document](https://docs.codecov.com/docs/error-reference#unusable-reports)
for assistance.

Looking into the [path fixing](https://docs.codecov.com/docs/fixing-paths) suggestions revealed the following
> For Codecov to operate correctly, all file paths in the coverage report must match the git file structure. This approach is how Codecov is able to correctly map coverage information in your uploaded coverage reports to the corresponding files in your repository. 

Investigating the attached [coverage.xml](https://storage.googleapis.com/codecov-production/shelter/github/spacetelescope%3A%3A%3A%3Amast-aladin-lite/141405b450f5a2cb69a9cfc532dc601cddf4a446/c0be76f8-fbd2-4d80-ae3b-601b3028dd44.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=GOOG1EJOGFN2JQ4OCTGA2MU5AEIT7OT5Z7HTFOAN2SPG4NWSN2UJYOY5U6LZQ%2F20250625%2Fus-west2%2Fs3%2Faws4_request&X-Amz-Date=20250625T144939Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=a3741ae28589e75d62e3d9c737453c354b3352aa536748e97eff72318678cd50) revealed that the wrong filepath was being generated, hence why codecov was failing to report.
```
<class name="aida.py" filename="D:/a/mast-aladin-lite/mast-aladin-lite/.tox/py311-test-cov/Lib/site-packages/mast_aladin_lite/aida.py" complexity="0" line-rate="0.8" branch-rate="0">
```

When we generate a coverage.xml locally, we can see what the filepath is supposed to look like 
```
<class name="aida.py" filename="mast_aladin_lite/aida.py" complexity="0" line-rate="0.8" branch-rate="0">
```
To fix this, all we need to do is explicitly set the `--cov-source` parameter on the `cov` command to `mast_aladin_lite` and the filepath should be correct moving forward 
