### PR TITLE
[bug] work around for codecov upload issue

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -90,6 +90,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Upload Coverage
     steps:
+    # work around CodeCov upload issue
+    # see: https://github.com/codecov/codecov-action/issues/1801
+    - uses: actions/checkout@v4
     - name: Download coverage artifacts
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
       with:


### PR DESCRIPTION
### What is this bug?
We have been receiving the following [code coverage errors](https://app.codecov.io/gh/spacetelescope/mast-aladin-lite/commit/141405b450f5a2cb69a9cfc532dc601cddf4a446)
> Unusable report due to issues such as source code unavailability, path mismatch, empty report, or incorrect data format. Please visit our [troubleshooting document](https://docs.codecov.com/docs/error-reference#unusable-reports)
    for assistance.

After investigation, it seems to be related to the following bug in codecov:
- https://github.com/codecov/codecov-action/issues/1801

### How is this fixed?
An effective workaround was identified by adding a checkout step to the job that uploads the coverage report to CodeCov.
- https://github.com/inclusive-design/idrc-cms-authenticator/pull/137

Note: I'm not 100% clear on why this addresses the issue, but it does seem to resolve it for us