### PR TITLE
Add mixin with methods that are delayed until render

### DIFF
--- a/mast_aladin_lite/app.py
+++ b/mast_aladin_lite/app.py
@@ -1,13 +1,14 @@
 from ipyaladin import Aladin
 from mast_aladin_lite.aida import AID
 from mast_aladin_lite.table import MastTable
+from mast_aladin_lite.mixins import DelayUntilRendered
 
 
 # store reference to the latest instantiation:
 _latest_instantiated_app = None
 
 
-class MastAladin(Aladin):
+class MastAladin(Aladin, DelayUntilRendered):
 
     def __init__(self, *args, **kwargs):
         # set ICRSd as the default visible coordinate system

--- a/mast_aladin_lite/mixins.py
+++ b/mast_aladin_lite/mixins.py
@@ -1,0 +1,66 @@
+from functools import wraps
+
+
+def delay_until_render(function, attr='_wcs'):
+    """
+    Delay a call on `function` until `attr` updates.
+    """
+
+    @wraps(function)
+    def wrapper(self, *args, **kwargs):
+        """Check if the widget is ready to execute a function.
+
+        Parameters
+        ----------
+        self : any
+            The widget object.
+        *args : any
+            The arguments of the function.
+        **kwargs : any
+            The keyword arguments of the function.
+
+        Returns
+        -------
+        any
+            The result of the function if the widget is ready.
+
+        """
+
+        # when the app is first constructed but not shown,
+        # `_wcs` is an empty dict, so `rendered` will be False.
+        # If `len(_wcs) > 0`, rendered will be True.
+        rendered = bool(min(len(getattr(self, attr)), 1))
+
+        def inner_func(change, rendered=rendered):
+            # if the app is not rendered:
+
+            if not rendered:
+                # On first render, unobserve the traitlet, then call function
+                rendered = True
+                self.unobserve(inner_func, attr)
+                return function(self, *args, **kwargs)
+
+        # on construction and before render, observe the traitlet
+        if not rendered:
+            self.observe(inner_func, attr)
+
+    return wrapper
+
+
+class DelayUntilRendered:
+
+    @delay_until_render
+    def delayed_add_fits(self, *args, **kwargs):
+        self.add_fits(*args, **kwargs)
+
+    @delay_until_render
+    def delayed_add_table(self, *args, **kwargs):
+        self.add_table(*args, **kwargs)
+
+    @delay_until_render
+    def delayed_add_graphic_overlay_from_stcs(self, *args, **kwargs):
+        self.add_graphic_overlay_from_stcs(*args, **kwargs)
+
+    @delay_until_render
+    def delayed_add_graphic_overlay_from_region(self, *args, **kwargs):
+        self.add_graphic_overlay_from_region(*args, **kwargs)

--- a/mast_aladin_lite/mixins.py
+++ b/mast_aladin_lite/mixins.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 
-def delay_until_render(function, attr='_wcs'):
+def delay_until_rendered(function, attr='_wcs'):
     """
     Delay a call on `function` until `attr` updates.
     """
@@ -27,8 +27,9 @@ def delay_until_render(function, attr='_wcs'):
         """
 
         # when the app is first constructed but not shown,
-        # `_wcs` is an empty dict, so `rendered` will be False.
-        # If `len(_wcs) > 0`, rendered will be True.
+        # the default attr `_wcs`` will be an empty dict,
+        # so `rendered` will be False. If `len(attr) > 0`,
+        # rendered will be True.
         rendered = bool(min(len(getattr(self, attr)), 1))
 
         def inner_func(change, rendered=rendered):
@@ -49,18 +50,30 @@ def delay_until_render(function, attr='_wcs'):
 
 class DelayUntilRendered:
 
-    @delay_until_render
+    @delay_until_rendered
     def delayed_add_fits(self, *args, **kwargs):
         self.add_fits(*args, **kwargs)
 
-    @delay_until_render
+    @delay_until_rendered
     def delayed_add_table(self, *args, **kwargs):
         self.add_table(*args, **kwargs)
 
-    @delay_until_render
+    @delay_until_rendered
     def delayed_add_graphic_overlay_from_stcs(self, *args, **kwargs):
         self.add_graphic_overlay_from_stcs(*args, **kwargs)
 
-    @delay_until_render
+    @delay_until_rendered
     def delayed_add_graphic_overlay_from_region(self, *args, **kwargs):
         self.add_graphic_overlay_from_region(*args, **kwargs)
+
+    @delay_until_rendered
+    def delayed_add_markers(self, *args, **kwargs):
+        self.add_markers(*args, **kwargs)
+
+    @delay_until_rendered
+    def delayed_add_catalog_from_URL(self, *args, **kwargs):
+        self.add_catalog_from_URL(*args, **kwargs)
+
+    @delay_until_rendered
+    def delayed_delayed_add_moc(self, *args, **kwargs):
+        self.add_moc(*args, **kwargs)

--- a/notebooks/demo-delayed-methods.ipynb
+++ b/notebooks/demo-delayed-methods.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9ffe879a-1d98-4498-9a63-1bf536f87be0",
+   "metadata": {},
+   "source": [
+    "# Delaying ipyaladin methods until render\n",
+    "\n",
+    "`ipyaladin.Aladin` methods take no action if they are called when the widget has not been displayed \n",
+    "\n",
+    "In this demo, we use `MastAladin.delayed_*` methods to queue an update to the widget that will execute one time, once the widget has been displayed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ea1acb7-2590-4d22-8a7e-db9d63459d19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mast_aladin_lite import MastAladin\n",
+    "from astroquery.mast import MastMissions\n",
+    "from astropy.io import fits\n",
+    "\n",
+    "\n",
+    "# download JWST image of M4 from MAST:\n",
+    "filename = 'jw01979002001_02201_00002_nis_rate.fits'\n",
+    "uri = f'jw01979002001_02201_00002/{filename}'\n",
+    "MastMissions(mission='jwst').download_file(uri)\n",
+    "\n",
+    "\n",
+    "# extract the image's perimeter from the header\n",
+    "s_region = fits.getheader(filename, ext=1)['S_REGION']\n",
+    "\n",
+    "\n",
+    "# initialize MAL, add STC-S region and FITS images\n",
+    "# using the `delayed_*` implementation\n",
+    "mast_aladin = MastAladin()\n",
+    "mast_aladin.delayed_add_graphic_overlay_from_stcs(s_region)\n",
+    "mast_aladin.delayed_add_fits(filename)\n",
+    "\n",
+    "# don't display the widget yet!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfec52e1-8c32-458b-a525-e777e6a9fe9b",
+   "metadata": {},
+   "source": [
+    "Now display the widget. Display will trigger the temporary callbacks to the `delayed_*` methods. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7574835e-29f8-46d4-b1b6-637667f13bdd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mast_aladin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0395aaf4-9348-454b-951a-e2339de5f3d5",
+   "metadata": {},
+   "source": [
+    "The widget is displayed and the FITS file and STC-S region graphic overlay are added once.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    Note: you'll need to zoom in to see the image and its bounding region.\n",
+    "</div>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/demo-delayed-methods.ipynb
+++ b/notebooks/demo-delayed-methods.ipynb
@@ -9,23 +9,25 @@
     "\n",
     "`ipyaladin.Aladin` methods take no action if they are called when the widget has not been displayed \n",
     "\n",
-    "In this demo, we use `MastAladin.delayed_*` methods to queue an update to the widget that will execute one time, once the widget has been displayed."
+    "In this demo, we use `MastAladin.delayed_*` methods to queue an update to the widget that will execute one time, once the widget has been displayed.\n",
+    "\n",
+    "The available `delayed` methods are: \n",
+    "\n",
+    "* `delayed_add_fits`\n",
+    "* `delayed_add_table`      \n",
+    "* `delayed_add_graphic_overlay_from_stcs`      \n",
+    "* `delayed_add_graphic_overlay_from_region`      \n",
+    "* `delayed_add_markers`      \n",
+    "* `delayed_add_catalog_from_URL`      \n",
+    "* `delayed_delayed_add_moc`\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1ea1acb7-2590-4d22-8a7e-db9d63459d19",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO: Found cached file jw01979002001_02201_00002_nis_rate.fits with expected size 83963520. [astroquery.query]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from mast_aladin_lite import MastAladin\n",
     "from astroquery.mast import MastMissions\n",
@@ -61,26 +63,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "7574835e-29f8-46d4-b1b6-637667f13bdd",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3c3fc5ec38d241fc84912832ce7c9f12",
-       "version_major": 2,
-       "version_minor": 1
-      },
-      "text/plain": [
-       "MastAladin(coo_frame='ICRSd')"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "mast_aladin"
    ]
@@ -96,6 +82,14 @@
     "    Note: you'll need to zoom in to see the image and its bounding region.\n",
     "</div>"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "239c9286-4a19-4cfe-b15d-c106db71b941",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/demo-delayed-methods.ipynb
+++ b/notebooks/demo-delayed-methods.ipynb
@@ -14,10 +14,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "1ea1acb7-2590-4d22-8a7e-db9d63459d19",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: Found cached file jw01979002001_02201_00002_nis_rate.fits with expected size 83963520. [astroquery.query]\n"
+     ]
+    }
+   ],
    "source": [
     "from mast_aladin_lite import MastAladin\n",
     "from astroquery.mast import MastMissions\n",
@@ -53,10 +61,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "7574835e-29f8-46d4-b1b6-637667f13bdd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3c3fc5ec38d241fc84912832ce7c9f12",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "MastAladin(coo_frame='ICRSd')"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "mast_aladin"
    ]


### PR DESCRIPTION
We've run into a known issue in ipyaladin (see https://github.com/cds-astro/ipyaladin/issues/128) where `Aladin` methods don't do anything if they're called before the widget is displayed.

This PR adds a mixin class with `delayed_*` versions of a few of the `Aladin` methods. If you call, e.g. `MastAladin.delayed_add_fits(path)`, the method adds a callback to call `Aladin.add_fits`, one time only, when the `_wcs` traitlet gets updated for the first time. On construction, `_wcs = dict()`, and after display, `_wcs` is a dictionary with a couple of entries.

I've added a demo notebook that shows how it works. If you want to compare to the existing behavior, just remove the `delayed_` part of the methods in the notebook.

We could consider making this a PR to ipyaladin, but since we know reviews will pile up over there, I'm putting the PR within our control here.