### PR TITLE
omitting everything from coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
 coverage:
-  status:
-    patch:
-      default:
-        target: 90%
-        threshold: 0.01%
+  ignore:
+    - "**/*"


### PR DESCRIPTION
Until we reevaluate that the metric is useful, we are going to eliminate codecov requirements on our repo. This PR updates the codecov.yml to ignore all files in all directories