### PR TITLE
sidecar launcher: open mast-aladin-lite and/or jdaviz in a sidecar

### DIFF
--- a/mast_aladin_lite/__init__.py
+++ b/mast_aladin_lite/__init__.py
@@ -4,4 +4,4 @@
 # Top-level API as exposed to users.
 from mast_aladin_lite.app import MastAladin, gca  # noqa: F401
 from mast_aladin_lite.table import MastTable  # noqa: F401
-from mast_aladin_lite.sidecar import sidecar  # noqa: F401
+from mast_aladin_lite.app_sidecar import AppSidecar  # noqa: F401

--- a/mast_aladin_lite/__init__.py
+++ b/mast_aladin_lite/__init__.py
@@ -2,5 +2,6 @@
 """Top-level package for mast_aladin_lite."""
 
 # Top-level API as exposed to users.
-from .app import MastAladin  # noqa: F401
-from .table import MastTable  # noqa: F401
+from mast_aladin_lite.app import MastAladin, gca  # noqa
+from mast_aladin_lite.table import MastTable  # noqa
+from mast_aladin_lite.sidecar import sidecar  # noqa

--- a/mast_aladin_lite/__init__.py
+++ b/mast_aladin_lite/__init__.py
@@ -2,6 +2,6 @@
 """Top-level package for mast_aladin_lite."""
 
 # Top-level API as exposed to users.
-from mast_aladin_lite.app import MastAladin, gca  # noqa
-from mast_aladin_lite.table import MastTable  # noqa
-from mast_aladin_lite.sidecar import sidecar  # noqa
+from mast_aladin_lite.app import MastAladin, gca  # noqa: F401
+from mast_aladin_lite.table import MastTable  # noqa: F401
+from mast_aladin_lite.sidecar import sidecar  # noqa: F401

--- a/mast_aladin_lite/app_sidecar.py
+++ b/mast_aladin_lite/app_sidecar.py
@@ -11,6 +11,7 @@ except ImportError:
     ConfigHelper = None
 
 opened_sidecars = []
+default_height = 500
 
 
 def is_jdaviz(app):
@@ -28,7 +29,7 @@ def is_aladin(app):
     return isinstance(app, Aladin)
 
 
-class sidecar:
+class AppSidecar:
     loaded_apps = []
     _sidecar_context = None
 
@@ -42,7 +43,7 @@ class sidecar:
         include_aladin=False,
         include_jdaviz=False,
         close_existing=True,
-        height=500,
+        height=default_height,
     ):
 
         """
@@ -121,7 +122,7 @@ class sidecar:
 
         except ImportError:
             warnings.warn(
-                "`sidecar` would open jdaviz, but it is not installed. To install it, "
+                "`AppSidecar` found that jdaviz was not installed. To install it, "
                 "run `pip install jdaviz`.",
                 UserWarning
             )
@@ -172,7 +173,7 @@ class sidecar:
         Close this particular `sidecar` instance.
         """
         # close jdaviz apps within the sidecar:
-        for app in sidecar.loaded_apps:
+        for app in self.loaded_apps:
             if is_jdaviz(app):
                 app.app.close()
 
@@ -190,7 +191,7 @@ class sidecar:
             sidecar.close()
 
     @staticmethod
-    def resize_all(height=400):
+    def resize_all(height=default_height):
         """
         Resize all opened sidecars with ``height`` in pixels.
         """
@@ -218,8 +219,8 @@ def set_app_height(app, height):
             app.height = -1
         elif isinstance(height, int):
             app.height = height
-        else:
-            warnings.warn(
-                f"height could not be set for unrecognized app: {app}",
-                UserWarning
-            )
+    else:
+        warnings.warn(
+            f"height could not be set for unrecognized app: {app}",
+            UserWarning
+        )

--- a/mast_aladin_lite/sidecar.py
+++ b/mast_aladin_lite/sidecar.py
@@ -1,0 +1,162 @@
+import solara
+import warnings
+from ipyaladin import Aladin
+from sidecar import Sidecar as UpstreamSidecar
+
+from mast_aladin_lite.app import MastAladin, gca
+
+__all__ = [
+    'sidecar'
+]
+
+opened_sidecars = []
+
+
+class sidecar:
+    loaded_apps = []
+    _sidecar_context = None
+
+    @classmethod
+    def open(
+        cls,
+        *apps,
+        anchor='split-bottom',
+        use_current_apps=False,
+        title='mast-aladin-lite & jdaviz',
+        include_aladin=True,
+        include_jdaviz=True,
+        close_existing=True,
+    ):
+
+        """
+        Open ``apps`` in a sidecar [1]_. If none are given and
+        ``include_aladin`` and ``include_jdaviz`` are `True`,
+        open a sidecar with one of each.
+
+        Parameters
+        ----------
+        anchor : str, optional (default is `'split-bottom'`)
+            One of the anchor location options available from
+            ``jupyterlab-sidecar``, which include:
+
+                {'split-right', 'split-left', 'split-top',
+                 'split-bottom', 'tab-before', 'tab-after',
+                 'right'}
+
+        use_current_apps : bool, optional (default is `False`)
+            If `True`, get the last constructed Imviz and
+            mast-aladin-lite instances to open in the sidecar
+
+        title : str, optional (default is 'mast-aladin-lite & jdaviz')
+            Title to appear in the tab label for the sidecar in
+            jupyterlab.
+
+        include_aladin : bool, optional (default is `True`)
+            The sidecar must include at least one
+            mast-aladin-lite instance. If none are already
+            available, a new one will be created.
+
+        include_jdaviz : bool, optional (default is `True`)
+            The sidecar must include at least one
+            jdaviz instance. If none are already available,
+            a new one will be created.
+
+        close_existing : bool, optional (default is `True`)
+            Close existing sidecar(s) before opening a new one.
+
+        References
+        ----------
+        .. [1] https://github.com/jupyter-widgets/jupyterlab-sidecar
+        """
+        # initialize the object here:
+        self = cls()
+
+        # This must be run first because we don't have the ability to close multiple
+        # sidecars without possibly closing all widgets
+        if close_existing:
+            cls.close_all()
+
+        apps = list(apps)
+        mal_instances = [app for app in apps if isinstance(app, Aladin)]
+        jdaviz_instances = []
+
+        if not len(mal_instances) and include_aladin:
+            mal = gca()
+            if not use_current_apps or (use_current_apps and mal is None):
+                mal = MastAladin()
+            apps.append(mal)
+
+        try:
+            from jdaviz.core.helpers import ConfigHelper
+            from jdaviz.configs.imviz.helper import Imviz, _current_app as viz
+
+            jdaviz_instances = [app for app in apps if isinstance(app, ConfigHelper)]
+
+            # construct new imviz if not using current app or no current app exists:
+            if not len(jdaviz_instances) and include_jdaviz:
+                if not use_current_apps or (use_current_apps and viz is None):
+                    viz = Imviz()
+                apps.append(viz)
+
+        except ImportError:
+            warnings.warn(
+                "`sidecar` would open jdaviz, but it is not installed. To install it, "
+                "run `pip install jdaviz`.",
+                UserWarning
+            )
+
+        n_columns = len(apps)
+
+        if not n_columns:
+            raise ValueError("No apps to show in sidecar.")
+
+        self.loaded_apps = apps
+
+        @solara.component
+        def SidecarContents(n_columns=n_columns):
+            # create layout with `n_columns` equal width columns
+            with solara.Columns(n_columns * [1], gutters_dense=True):
+
+                for app in apps:
+                    if isinstance(app, Aladin):
+                        # MastAladin:
+                        with solara.Column():
+                            app.height = 600
+                            solara.display(app)
+                    elif app.__class__.__name__.endswith('viz'):
+                        # jdaviz:
+                        with solara.Column():
+                            solara.display(app.app)
+                    else:
+                        # other:
+                        with solara.Column():
+                            solara.display(app)
+
+        self._sidecar_context = UpstreamSidecar(anchor=anchor, title=title)
+        with self._sidecar_context:
+            solara.display(SidecarContents())
+
+        opened_sidecars.append(self)
+        return tuple(apps)
+
+    def close(self):
+        """
+        Close this particular `sidecar` instance.
+        """
+        # close jdaviz apps within the sidecar:
+        for app in sidecar.loaded_apps:
+            if app.__class__.__name__.endswith('viz'):
+                app.app.close()
+
+        # now close sidecar(s):
+        if self._sidecar_context is not None:
+            self._sidecar_context.close()
+
+    @classmethod
+    def close_all(cls):
+        """
+        Close all `sidecar` instances.
+        """
+        while len(opened_sidecars):
+            sidecar = opened_sidecars.pop()
+            sidecar.close()

--- a/notebooks/demo-sidecar-launcher.ipynb
+++ b/notebooks/demo-sidecar-launcher.ipynb
@@ -34,8 +34,26 @@
    "id": "1ec42327-64bb-4ba4-9685-5ab5e3242def",
    "metadata": {},
    "source": [
-    "`sidecar.open` returns a tuple of the initialized apps.\n",
+    "`sidecar.open()` returns a tuple of the initialized apps.\n",
     "\n",
+    "The default app height is 500 pixels. You can resize the height of the apps within the sidecar to other sizes like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b7db210-493a-4cb3-9f92-9f9dce0bd4eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sidecar.resize_all(400)  # [pixels]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf208ac0-3d87-4a34-8f9e-56f0300bf976",
+   "metadata": {},
+   "source": [
     "You can also open a sidecar with apps that are already initialized. Let's create instances of `Imviz` and `MastAladin`:"
    ]
   },
@@ -62,7 +80,6 @@
     "We can create a new sidecar with each widget, in the reverse order this time. Opening a new sidecar will close existing sidecars by default. Setting `anchor` allows you to choose where you want the sidecar to appear. Options include: \n",
     "\n",
     "* `'split-right'`, `'split-left'`, `'split-top'`, or `'split-bottom'`: open a sidecar in a draggable tab that can be moved to any of these four positions, or alongside the tab of the notebook.\n",
-    "* \n",
     "* `'tab-before'`, `'tab-after'`: open a sidecar in the tab before/after the tab of the notebook that launches the sidecar.\n",
     "* `'right'`: open a sidecar in a collapsible tab from Jupyterlab's right sidebar (near the Settings (cog wheels) and Debugger buttons). This sidebar cannot be dragged around."
    ]
@@ -76,6 +93,14 @@
    "source": [
     "apps_initialized = sidecar.open(viz, mal_1)\n",
     "apps_initialized"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09d544c8-af21-4346-bd52-fa3414ae257d",
+   "metadata": {},
+   "source": [
+    "You can check that the returned apps are the ones that you constructed:"
    ]
   },
   {
@@ -113,9 +138,9 @@
    "id": "4fe03c73-6ab4-4703-a575-da89c7232ba1",
    "metadata": {},
    "source": [
-    "By default, at least `mast-aladin-lite` and one `jdaviz` will be included in the result. \n",
+    "By default, there is no requirement to have both `mast-aladin-lite` and `jdaviz` in the result. \n",
     "\n",
-    "You can control this with the keywords: `include_jdaviz` or `include_aladin`"
+    "You can make sure there are at least one instance of either app with: `include_jdaviz=True` and/or `include_aladin=True`."
    ]
   },
   {
@@ -126,7 +151,7 @@
    "outputs": [],
    "source": [
     "sidecar.open(\n",
-    "    mal_1, mal_2, include_jdaviz=False\n",
+    "    mal_1, mal_2, include_jdaviz=True\n",
     ")"
    ]
   },
@@ -146,7 +171,7 @@
    "outputs": [],
    "source": [
     "sidecar.open(\n",
-    "    mal_1, mal_2, include_jdaviz=False, close_existing=False\n",
+    "    mal_1, mal_2, close_existing=False\n",
     ")"
    ]
   },
@@ -171,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4fd5f896-0698-443d-9958-4c953a19116f",
+   "id": "ef809163-2631-48e8-9e43-d89a858a2084",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/demo-sidecar-launcher.ipynb
+++ b/notebooks/demo-sidecar-launcher.ipynb
@@ -1,0 +1,188 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0e679436-b9b6-4446-bb5f-9ebaaff9f305",
+   "metadata": {},
+   "source": [
+    "# Demo: launch apps in a sidecar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45f1d756-f109-4b35-b358-43440fed1c40",
+   "metadata": {},
+   "source": [
+    "Let's begin by constructing isntances of `Imviz` and `MastAladin` together in a sidecar:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1853948e-0cb1-4316-8192-8c1d4211ba9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mast_aladin_lite import sidecar\n",
+    "\n",
+    "apps = sidecar.open()\n",
+    "apps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ec42327-64bb-4ba4-9685-5ab5e3242def",
+   "metadata": {},
+   "source": [
+    "`sidecar.open` returns a tuple of the initialized apps.\n",
+    "\n",
+    "You can also open a sidecar with apps that are already initialized. Let's create instances of `Imviz` and `MastAladin`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8efac0c3-379a-4498-a546-75220baba944",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jdaviz import Imviz\n",
+    "from mast_aladin_lite import MastAladin\n",
+    "\n",
+    "viz = Imviz()\n",
+    "mal_1 = MastAladin()\n",
+    "mal_2 = MastAladin()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4198bddc-f854-4834-8755-2cc99f6e7155",
+   "metadata": {},
+   "source": [
+    "We can create a sidecar with each widget, in the reverse order this time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "866c1376-1682-47ac-b8b5-a9fa45eaf8a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "apps_initialized = sidecar.open(viz, mal_1)\n",
+    "apps_initialized"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf9bcd42-8b3b-40ca-9ab8-e04964b445ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "apps_initialized[0] is viz, apps_initialized[1] is mal_1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f25e4fb7-8aa2-4093-ab9a-e93841c57bb1",
+   "metadata": {},
+   "source": [
+    "You can also create a configuration with as many apps as you like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05c18c03-e5a1-4579-ba48-9ce50e3ef5a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sidecar.open(\n",
+    "    mal_1, mal_2\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fe03c73-6ab4-4703-a575-da89c7232ba1",
+   "metadata": {},
+   "source": [
+    "By default, at least `mast-aladin-lite` and one `jdaviz` will be included in the result. \n",
+    "\n",
+    "You can control this with the keywords: `include_jdaviz` or `include_aladin`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93468eea-8d6f-4fef-8321-a6be8bc906b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sidecar.open(\n",
+    "    mal_1, mal_2, include_jdaviz=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "273cb757-4719-46cd-9f29-b17363263864",
+   "metadata": {},
+   "source": [
+    "By default, `Sidecar` will close existing sidecars. If you don't mind a crowded screen, you can turn that off:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f495da68-ce51-488a-b9d9-e4d6b98c2ebb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sidecar.open(\n",
+    "    mal_1, mal_2, include_jdaviz=False, close_existing=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0330f137-4f28-4901-b498-dfce02ecec50",
+   "metadata": {},
+   "source": [
+    "And if you end up with too many sidecars open at once, you can close them _all_ with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "878afca0-34c0-47f6-b7d1-2f89da0898a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sidecar.close_all()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/demo-sidecar-launcher.ipynb
+++ b/notebooks/demo-sidecar-launcher.ipynb
@@ -59,7 +59,12 @@
    "id": "4198bddc-f854-4834-8755-2cc99f6e7155",
    "metadata": {},
    "source": [
-    "We can create a sidecar with each widget, in the reverse order this time:"
+    "We can create a new sidecar with each widget, in the reverse order this time. Opening a new sidecar will close existing sidecars by default. Setting `anchor` allows you to choose where you want the sidecar to appear. Options include: \n",
+    "\n",
+    "* `'split-right'`, `'split-left'`, `'split-top'`, or `'split-bottom'`: open a sidecar in a draggable tab that can be moved to any of these four positions, or alongside the tab of the notebook.\n",
+    "* \n",
+    "* `'tab-before'`, `'tab-after'`: open a sidecar in the tab before/after the tab of the notebook that launches the sidecar.\n",
+    "* `'right'`: open a sidecar in a collapsible tab from Jupyterlab's right sidebar (near the Settings (cog wheels) and Debugger buttons). This sidebar cannot be dragged around."
    ]
   },
   {
@@ -99,7 +104,7 @@
    "outputs": [],
    "source": [
     "sidecar.open(\n",
-    "    mal_1, mal_2\n",
+    "    mal_1, mal_2, anchor='right'\n",
     ")"
    ]
   },
@@ -130,7 +135,7 @@
    "id": "273cb757-4719-46cd-9f29-b17363263864",
    "metadata": {},
    "source": [
-    "By default, `Sidecar` will close existing sidecars. If you don't mind a crowded screen, you can turn that off:"
+    "By default, `sidecar.open()` will close existing sidecars. If you don't mind a crowded screen, you can turn that off:"
    ]
   },
   {
@@ -162,6 +167,14 @@
    "source": [
     "sidecar.close_all()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fd5f896-0698-443d-9958-4c953a19116f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/demo-sidecar-launcher.ipynb
+++ b/notebooks/demo-sidecar-launcher.ipynb
@@ -23,9 +23,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mast_aladin_lite import sidecar\n",
+    "from mast_aladin_lite import AppSidecar\n",
     "\n",
-    "apps = sidecar.open()\n",
+    "apps = AppSidecar.open()\n",
     "apps"
    ]
   },
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sidecar.resize_all(400)  # [pixels]"
+    "AppSidecar.resize_all(400)  # [pixels]"
    ]
   },
   {
@@ -91,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "apps_initialized = sidecar.open(viz, mal_1)\n",
+    "apps_initialized = AppSidecar.open(viz, mal_1)\n",
     "apps_initialized"
    ]
   },
@@ -128,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sidecar.open(\n",
+    "AppSidecar.open(\n",
     "    mal_1, mal_2, anchor='right'\n",
     ")"
    ]
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sidecar.open(\n",
+    "AppSidecar.open(\n",
     "    mal_1, mal_2, include_jdaviz=True\n",
     ")"
    ]
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sidecar.open(\n",
+    "AppSidecar.open(\n",
     "    mal_1, mal_2, close_existing=False\n",
     ")"
    ]
@@ -190,7 +190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sidecar.close_all()"
+    "AppSidecar.close_all()"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "ipypopout",
     "ipyvuetify",
     "ipywidgets",
+    "solara",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
This PR adds a feature that I kept reusing on the path towards #43, which we could also use in lots of other contexts.

The best introduction to the code is to try using the new features for yourself, see the demo notebook that I've included in the PR. Here's a quick movie of how it looks:

https://github.com/user-attachments/assets/6d00af04-b64d-4501-a545-a4a302e04f75

When you call `result = sidecar.open(*apps)`, you get a new sidecar. If `apps` isn't given, the user gets a fresh instance of mast-aladin-lite and jdaviz, and `result` is a tuple of the apps. 

You can initialize the sidecar with specific instances like:
```python
from jdaviz import Imviz
from mast_aladin_lite import MastAladin, sidecar

viz = Imviz()
mal = MastAladin()
sidecar.open(viz, mal)
```
and those instances will appear in the new sidecar, in the order that you've listed them. This implementation supports `len(apps) >= 0` in evenly divided columns, though you should be skeptical of performance and usability for large `len(apps)`.

If you call `sidecar.open` more than once in a session, the default behavior is to close any other open sidecars. You can opt into keeping all sidecars open, though that choice will make your screen quite crowded and unhelpful for users on typical laptops or monitors.

If you've made such a mistake, you can call `sidecar.close_all()`, and you will be absolved of the chaos.