### PR TITLE
python version bump 3.10->3.11

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -50,10 +50,10 @@ jobs:
             toxenv: py311-test-cov
             allow_failure: false
 
-          - name: macOS - Python 3.10
+          - name: macOS - Python 3.11
             os: macos-latest
-            python: '3.10'
-            toxenv: py310-test
+            python: '3.11'
+            toxenv: py311-test
             allow_failure: false
 
           - name: Windows - Python 3.11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install python-build and twine
       run: python -m pip install build "twine>=3.3"

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,8 +10,8 @@ User Installation
 
 Set Up Your Local Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To use mast-aladin-lite, you need `Python 3.10` or later. Below is an example using `Python 3.11`, but you can 
-replace 3.11 with any supported version (e.g., 3.10, 3.12).
+To use mast-aladin-lite, you need `Python 3.11` or later. Below is an example using `Python 3.11`, but you can 
+replace 3.11 with any supported version (e.g., 3.12).
 
 1. **Create a new Conda environment:**
 

--- a/mast_aladin_lite/conftest.py
+++ b/mast_aladin_lite/conftest.py
@@ -13,7 +13,8 @@ def MastAladin_app():
 @pytest.fixture
 def imviz_helper():
     return Imviz()
-  
+
+
 @pytest.fixture
 def mast_observation_table():
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mast-aladin-lite"
 description = "Visualize MAST data products in Aladin Lite"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "mast-aladin-lite developers", email = "help@stsci.edu" },
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-    py{310,311}-test-devdeps{,-cov}
+    py{311}-test-devdeps{,-cov}
     linkcheck
     codestyle
     pep517


### PR DESCRIPTION
### What is changing?
python version bump 3.10->3.11

### Why is this change required?
In response to [jdaviz](https://github.com/spacetelescope/jdaviz/pull/3510) bumping the minimum python version it supports from 3.10 -> 3.11, we are following suit and increasing our minimum python version required to 3.11.