### PR TITLE
CST-295 Update Overlays

### DIFF
--- a/mast_aladin_lite/app.py
+++ b/mast_aladin_lite/app.py
@@ -332,8 +332,8 @@ class MastAladin(Aladin, DelayUntilRendered):
         overlay.options.update(new_options)
 
         if overlay_type == "marker":
-            update_info = overlay["update_info"]
-            overlay_info = self.add_markers(update_info, **overlay.options)
+            markers = overlay["update_info"]
+            overlay_info = self.add_markers(markers, **overlay.options)
         elif overlay_type == "catalog":
             overlay_info = self.add_catalog_from_URL(overlay["votable_URL"], overlay.options)
         elif overlay_type == "table":
@@ -343,19 +343,17 @@ class MastAladin(Aladin, DelayUntilRendered):
                 **overlay.options
             )
         elif overlay_type == "overlay_region":
-            update_info = overlay["update_info"]
-            new_regions = []
-            for region in update_info:
+            regions = overlay["update_info"]
+            for region in regions:
                 style = overlay.options.copy()
                 if "color" in style:
                     style["edgecolor"] = style["color"]
                 style.pop("name", None)
                 region.visual.update(style)
-                new_regions.append(region)
-            overlay_info = self.add_graphic_overlay_from_region(update_info, **overlay.options)
+            overlay_info = self.add_graphic_overlay_from_region(regions, **overlay.options)
         elif overlay_type == "overlay_stcs":
-            update_info = overlay["update_info"]
-            overlay_info = self.add_graphic_overlay_from_stcs(update_info, **overlay.options)
+            stcs_strings = overlay["update_info"]
+            overlay_info = self.add_graphic_overlay_from_stcs(stcs_strings, **overlay.options)
 
         return overlay_info
 

--- a/mast_aladin_lite/app.py
+++ b/mast_aladin_lite/app.py
@@ -323,22 +323,23 @@ class MastAladin(Aladin, DelayUntilRendered):
 
         if not new_options:
             raise ValueError(
-                f"Cannot update overlayer `{overlay.name}` since no options to update were provided."
+                f"Cannot update overlayer `{overlay.name}` since no options to "
+                "update were provided."
             )
 
         self.remove_overlay(overlay)
         overlay_type = overlay.type
         overlay.options.update(new_options)
 
-        if overlay_type ==  "marker":
+        if overlay_type == "marker":
             update_info = overlay["update_info"]
             overlay_info = self.add_markers(update_info, **overlay.options)
         elif overlay_type == "catalog":
-            overlay_info = self.add_catalog_from_URL(overlay["votable_URL"],overlay.options)
+            overlay_info = self.add_catalog_from_URL(overlay["votable_URL"], overlay.options)
         elif overlay_type == "table":
             overlay_info = self.add_table(
                 overlay["table"],
-                shape=overlay.options.get("shape","cross"),
+                shape=overlay.options.get("shape", "cross"),
                 **overlay.options
             )
         elif overlay_type == "overlay_region":
@@ -357,6 +358,7 @@ class MastAladin(Aladin, DelayUntilRendered):
             overlay_info = self.add_graphic_overlay_from_stcs(update_info, **overlay.options)
 
         return overlay_info
+
 
 def gca():
     """

--- a/mast_aladin_lite/app.py
+++ b/mast_aladin_lite/app.py
@@ -45,7 +45,7 @@ class MastAladin(Aladin, DelayUntilRendered):
         global _latest_instantiated_app
         _latest_instantiated_app = self
 
-        self._overlays_dict = OverlayManager()
+        self._overlays_dict = OverlayManager(self)
 
     def load_table(
         self,
@@ -311,51 +311,6 @@ class MastAladin(Aladin, DelayUntilRendered):
                 )
 
             self._overlays_dict.pop(name)
-
-    def update_overlay(self, overlay, **new_options):
-
-        if isinstance(overlay, str):
-            overlay = self._overlays_dict[overlay]
-        elif not isinstance(overlay, MastOverlay):
-            raise TypeError(
-                "overlay must be a str, MastOverlay, or iterable of these."
-            )
-
-        if not new_options:
-            raise ValueError(
-                f"Cannot update overlayer `{overlay.name}` since no options to "
-                "update were provided."
-            )
-
-        self.remove_overlay(overlay)
-        overlay_type = overlay.type
-        overlay.options.update(new_options)
-
-        if overlay_type == "marker":
-            markers = overlay["update_info"]
-            overlay_info = self.add_markers(markers, **overlay.options)
-        elif overlay_type == "catalog":
-            overlay_info = self.add_catalog_from_URL(overlay["votable_URL"], overlay.options)
-        elif overlay_type == "table":
-            overlay_info = self.add_table(
-                overlay["table"],
-                shape=overlay.options.get("shape", "cross"),
-                **overlay.options
-            )
-        elif overlay_type == "overlay_region":
-            regions = overlay["update_info"]
-            for region in regions:
-                style = overlay.options.copy()
-                if "color" in style:
-                    style["edgecolor"] = style["color"]
-                style.pop("name", None)
-                region.visual.update(style)
-            overlay_info = self.add_graphic_overlay_from_region(regions, **overlay.options)
-        elif overlay_type == "overlay_stcs":
-            stcs_strings = overlay["update_info"]
-            overlay_info = self.add_graphic_overlay_from_stcs(stcs_strings, **overlay.options)
-
-        return overlay_info
 
 
 def gca():

--- a/mast_aladin_lite/overlay/mast_overlay.py
+++ b/mast_aladin_lite/overlay/mast_overlay.py
@@ -10,7 +10,8 @@ class MastOverlayType(Enum):
 
 
 class MastOverlay(dict):
-    def __init__(self, overlay_info):
+    def __init__(self, overlay_info, mast_aladin):
+        self.app = mast_aladin
         overlay_type = overlay_info.get("type")
         if overlay_type not in {t.value for t in MastOverlayType}:
             raise ValueError(
@@ -35,3 +36,41 @@ class MastOverlay(dict):
     def data(self):
         ignored = ["type", "options"]
         return {key: value for key, value in self.items() if key not in ignored}
+
+    def update(self, **new_options):
+        if not new_options:
+            raise ValueError(
+                f"Cannot update overlayer `{self.name}` since no options to "
+                "update were provided."
+            )
+
+        self.app.remove_overlay(self)
+        updated_options = {**self.options, **new_options}
+
+        if self.type == MastOverlayType.MARKER.value:
+            markers = self.get("update_info")
+            overlay_info = self.app.add_markers(markers, **updated_options)
+        elif self.type == MastOverlayType.CATALOG.value:
+            overlay_info = self.app.add_catalog_from_URL(self["votable_URL"], updated_options)
+        elif self.type == MastOverlayType.TABLE.value:
+            overlay_info = self.app.add_table(
+                self["table"],
+                shape=self.options.get("shape", "cross"),
+                **updated_options
+            )
+        elif self.type == MastOverlayType.OVERLAY_REGION.value:
+            regions = self["update_info"]
+            new_regions = []
+            for region in regions:
+                style = self.options.copy()
+                if "color" in style:
+                    style["edgecolor"] = style["color"]
+                style.pop("name", None)
+                region.visual.update(style)
+                new_regions.append(region)
+            overlay_info = self.app.add_graphic_overlay_from_region(regions, **updated_options)
+        elif self.type == MastOverlayType.OVERLAY_STCS.value:
+            update_info = self["update_info"]
+            overlay_info = self.app.add_graphic_overlay_from_stcs(update_info, **updated_options)
+
+        return overlay_info

--- a/mast_aladin_lite/overlay/overlay_manager.py
+++ b/mast_aladin_lite/overlay/overlay_manager.py
@@ -3,7 +3,8 @@ from mast_aladin_lite.overlay.mast_overlay import MastOverlay
 
 
 class OverlayManager:
-    def __init__(self):
+    def __init__(self, mast_aladin):
+        self.app = mast_aladin
         self._overlays_dict = {}
 
     def __setitem__(self, key, value):
@@ -90,7 +91,7 @@ class OverlayManager:
             The overlay options for the layer being added to the widget.
         """
 
-        overlay_info = MastOverlay(overlay_info)
+        overlay_info = MastOverlay(overlay_info, self.app)
 
         self[overlay_info["options"]["name"]] = overlay_info
 

--- a/mast_aladin_lite/tests/test_overlays_dict.py
+++ b/mast_aladin_lite/tests/test_overlays_dict.py
@@ -328,19 +328,25 @@ def test_invalid_overlay_type(
             f"Must be one of {[t.value for t in MastOverlayType]}."
         )
     ):
-        MastOverlay(test_invalid_overlay)
+        MastOverlay(test_invalid_overlay, mast_aladin)
 
 
-test_marker_overlay = MastOverlay({
-    "type": "marker",
-    "options": {"name": "test_markers"}
-})
+test_marker_overlay = MastOverlay(
+    {
+        "type": "marker",
+        "options": {"name": "test_markers"}
+    },
+    mast_aladin,
+)
 
 
-test_catalog_overlay = MastOverlay({
-    "type": "catalog",
-    "options": {"name": "test_catalog"}
-})
+test_catalog_overlay = MastOverlay(
+    {
+        "type": "catalog",
+        "options": {"name": "test_catalog"}
+    },
+    mast_aladin,
+)
 
 
 test_overlays = [

--- a/mast_aladin_lite/tests/test_overlays_update.py
+++ b/mast_aladin_lite/tests/test_overlays_update.py
@@ -37,7 +37,7 @@ def test_overlays_dict_add_markers():
 
     updated_options = options.copy()
     updated_options.update(
-        {"name":test_name + "_1", "color":"red", "shape":"random", "source_size":20}
+        {"name": test_name + "_1", "color": "red", "shape": "random", "source_size": 20}
     )
 
     marker_overlay = mast_aladin.update_overlay(
@@ -69,7 +69,7 @@ def test_overlays_dict_add_catalog_from_URL():
 
     updated_options = options.copy()
     updated_options.update(
-        {"name":test_name + "_1", "color":"#66FF00", "source_size":20}
+        {"name": test_name + "_1", "color": "#66FF00", "source_size": 20}
     )
 
     url_overlay = mast_aladin.update_overlay(
@@ -106,7 +106,7 @@ def test_overlays_dict_add_table():
 
     updated_options = options.copy()
     updated_options.update(
-        {"name":test_name + "_1"}
+        {"name": test_name + "_1"}
     )
 
     table_overlay = mast_aladin.update_overlay(
@@ -127,8 +127,8 @@ def test_overlays_dict_add_graphic_overlay_from_region():
     test_name = "test"
 
     circle = CircleSkyRegion(
-        center=SkyCoord.from_name("M31"), 
-        radius=Angle(0.5, "deg"), 
+        center=SkyCoord.from_name("M31"),
+        radius=Angle(0.5, "deg"),
         visual={"edgecolor": "yellow"}
     )
     options = {"name": test_name}
@@ -139,7 +139,7 @@ def test_overlays_dict_add_graphic_overlay_from_region():
 
     updated_options = options.copy()
     updated_options.update(
-        {"name":test_name + "_1", "color": "#66FF00"}
+        {"name": test_name + "_1", "color": "#66FF00"}
     )
 
     region_overlay = mast_aladin.update_overlay(
@@ -174,7 +174,7 @@ def test_overlays_dict_add_graphic_overlay_from_stcs_(
     mast_aladin = MastAladin()
 
     test_name = "test"
-    options = {"name": test_name, "color":"red"}
+    options = {"name": test_name, "color": "red"}
     stcs_overlay = mast_aladin.add_graphic_overlay_from_stcs(stcs_strings, **options)
 
     assert type(stcs_overlay) is MastOverlay
@@ -182,7 +182,7 @@ def test_overlays_dict_add_graphic_overlay_from_stcs_(
 
     updated_options = options.copy()
     updated_options.update(
-        {"name":test_name + "_1", "color": "#66FF00"}
+        {"name": test_name + "_1", "color": "#66FF00"}
     )
 
     stcs_overlay = mast_aladin.update_overlay(

--- a/mast_aladin_lite/tests/test_overlays_update.py
+++ b/mast_aladin_lite/tests/test_overlays_update.py
@@ -39,10 +39,7 @@ def test_overlays_dict_add_markers():
         {"name": test_name + "_1", "color": "red", "shape": "random", "source_size": 20}
     )
 
-    marker_overlay = mast_aladin.update_overlay(
-        marker_overlay,
-        **updated_options,
-    )
+    marker_overlay = marker_overlay.update(**updated_options)
 
     assert test_name not in mast_aladin._overlays_dict
     assert test_name + "_1" in mast_aladin._overlays_dict
@@ -71,10 +68,7 @@ def test_overlays_dict_add_catalog_from_URL():
         {"name": test_name + "_1", "color": "#66FF00", "source_size": 20}
     )
 
-    url_overlay = mast_aladin.update_overlay(
-        url_overlay,
-        **updated_options,
-    )
+    url_overlay = url_overlay.update(**updated_options)
 
     assert test_name not in mast_aladin._overlays_dict
     assert test_name + "_1" in mast_aladin._overlays_dict
@@ -108,10 +102,7 @@ def test_overlays_dict_add_table():
         {"name": test_name + "_1"}
     )
 
-    table_overlay = mast_aladin.update_overlay(
-        table_overlay,
-        **updated_options,
-    )
+    table_overlay = table_overlay.update(**updated_options)
 
     assert test_name not in mast_aladin._overlays_dict
     assert test_name + "_1" in mast_aladin._overlays_dict
@@ -141,10 +132,7 @@ def test_overlays_dict_add_graphic_overlay_from_region():
         {"name": test_name + "_1", "color": "#66FF00"}
     )
 
-    region_overlay = mast_aladin.update_overlay(
-        region_overlay,
-        **updated_options,
-    )
+    region_overlay = region_overlay.update(**updated_options)
 
     assert test_name not in mast_aladin._overlays_dict
     assert test_name + "_1" in mast_aladin._overlays_dict
@@ -170,10 +158,7 @@ def test_overlays_dict_add_graphic_overlay_from_stcs_():
         {"name": test_name + "_1", "color": "#66FF00"}
     )
 
-    stcs_overlay = mast_aladin.update_overlay(
-        stcs_overlay,
-        **updated_options,
-    )
+    stcs_overlay = stcs_overlay.update(**updated_options)
 
     assert test_name not in mast_aladin._overlays_dict
     assert test_name + "_1" in mast_aladin._overlays_dict

--- a/mast_aladin_lite/tests/test_overlays_update.py
+++ b/mast_aladin_lite/tests/test_overlays_update.py
@@ -1,6 +1,5 @@
 from astropy.table import Table
 from astropy.coordinates import SkyCoord, Angle
-import pytest
 
 from mast_aladin_lite import MastAladin
 from mast_aladin_lite.overlay.mast_overlay import MastOverlay
@@ -154,25 +153,11 @@ def test_overlays_dict_add_graphic_overlay_from_region():
     assert region_overlay.options == updated_options
 
 
-test_stcs_iterables = [
-    "CIRCLE ICRS 258.93205686 43.13632863 0.625",
-]
-
-
-@pytest.mark.parametrize("stcs_strings", test_stcs_iterables)
-def test_overlays_dict_add_graphic_overlay_from_stcs_(
-    stcs_strings,
-):
-    """Test overlays_dict overlay info from adding iterable STC-S string(s).
-
-    Parameters
-    ----------
-    stcs_strings : Union[Iterable[str], str]
-        The stcs strings to create region overlay info from.
-
-    """
+def test_overlays_dict_add_graphic_overlay_from_stcs_():
+    """Test overlays_dict overlay info from adding iterable STC-S string(s)."""
     mast_aladin = MastAladin()
 
+    stcs_strings = "CIRCLE ICRS 258.93205686 43.13632863 0.625"
     test_name = "test"
     options = {"name": test_name, "color": "red"}
     stcs_overlay = mast_aladin.add_graphic_overlay_from_stcs(stcs_strings, **options)

--- a/mast_aladin_lite/tests/test_overlays_update.py
+++ b/mast_aladin_lite/tests/test_overlays_update.py
@@ -1,0 +1,197 @@
+from astropy.table import Table
+from astropy.coordinates import SkyCoord, Angle
+import pytest
+
+from mast_aladin_lite import MastAladin
+from mast_aladin_lite.overlay.mast_overlay import MastOverlay
+from ipyaladin.elements.error_shape import CircleError
+from regions import CircleSkyRegion
+from ipyaladin import Marker
+
+
+def test_overlays_dict_add_markers():
+    """Test overlays_dict overlay info from adding markers."""
+    mast_aladin = MastAladin()
+
+    test_name = "test"
+
+    markers = []
+    for i in range(1, 11):
+        name = f"M{i}"
+        markers.append(
+            Marker(
+                position=name,
+                title=name,
+                description=(
+                    '<a href="https://simbad.cds.unistra.fr/simbad/'
+                    f'sim-basic?Ident={name}&submit=SIMBAD+search"> '
+                    "Read more on SIMBAD</a>"
+                ),
+            )
+        )
+    options = {"name": test_name, "color": "pink", "shape": "cross", "source_size": 15}
+    marker_overlay = mast_aladin.add_markers(markers, **options)
+
+    assert type(marker_overlay) is MastOverlay
+    assert marker_overlay.options == options
+
+    updated_options = options.copy()
+    updated_options.update(
+        {"name":test_name + "_1", "color":"red", "shape":"random", "source_size":20}
+    )
+
+    marker_overlay = mast_aladin.update_overlay(
+        marker_overlay,
+        **updated_options,
+    )
+
+    assert test_name not in mast_aladin._overlays_dict
+    assert test_name + "_1" in mast_aladin._overlays_dict
+    assert marker_overlay.name == updated_options["name"]
+    assert marker_overlay.options == updated_options
+
+
+def test_overlays_dict_add_catalog_from_URL():
+    """Test overlays_dict overlay info from adding catalog using its URL."""
+    mast_aladin = MastAladin()
+
+    test_name = "test"
+
+    url = (
+        "https://vizier.unistra.fr/viz-bin/votable?-source=HIP2&-c=LMC&-out.add=_RAJ,_"
+        "DEJ&-oc.form=dm&-out.meta=DhuL&-out.max=9999&-c.rm=180"
+    )
+    options = {"source_size": 12, "color": "#f08080", "on_click": "showTable", "name": test_name}
+    url_overlay = mast_aladin.add_catalog_from_URL(url, options)
+
+    assert type(url_overlay) is MastOverlay
+    assert url_overlay.options == options
+
+    updated_options = options.copy()
+    updated_options.update(
+        {"name":test_name + "_1", "color":"#66FF00", "source_size":20}
+    )
+
+    url_overlay = mast_aladin.update_overlay(
+        url_overlay,
+        **updated_options,
+    )
+
+    assert test_name not in mast_aladin._overlays_dict
+    assert test_name + "_1" in mast_aladin._overlays_dict
+    assert url_overlay.name == updated_options["name"]
+    assert url_overlay.options == updated_options
+
+
+def test_overlays_dict_add_table():
+    """Test overlays_dict overlay info from a table."""
+    mast_aladin = MastAladin()
+
+    test_name = "test"
+    table = Table({"a": [1, 2, 3]})
+    table["a"].unit = "deg"
+
+    options = {
+        "color": "pink", "name": test_name,
+        "circle_error": {"radius": "a", "conversion_radius": 1}
+    }
+    table_overlay = mast_aladin.add_table(
+        table,
+        shape=CircleError(radius="a", default_shape="cross"),
+        **options,
+    )
+
+    assert type(table_overlay) is MastOverlay
+    assert table_overlay.options == options
+
+    updated_options = options.copy()
+    updated_options.update(
+        {"name":test_name + "_1"}
+    )
+
+    table_overlay = mast_aladin.update_overlay(
+        table_overlay,
+        **updated_options,
+    )
+
+    assert test_name not in mast_aladin._overlays_dict
+    assert test_name + "_1" in mast_aladin._overlays_dict
+    assert table_overlay.name == updated_options["name"]
+    assert table_overlay.options == updated_options
+
+
+def test_overlays_dict_add_graphic_overlay_from_region():
+    """Test overlays_dict overlay info from adding region overlay."""
+    mast_aladin = MastAladin()
+
+    test_name = "test"
+
+    circle = CircleSkyRegion(
+        center=SkyCoord.from_name("M31"), 
+        radius=Angle(0.5, "deg"), 
+        visual={"edgecolor": "yellow"}
+    )
+    options = {"name": test_name}
+    region_overlay = mast_aladin.add_graphic_overlay_from_region([circle], **options)
+
+    assert type(region_overlay) is MastOverlay
+    assert region_overlay.options == options
+
+    updated_options = options.copy()
+    updated_options.update(
+        {"name":test_name + "_1", "color": "#66FF00"}
+    )
+
+    region_overlay = mast_aladin.update_overlay(
+        region_overlay,
+        **updated_options,
+    )
+
+    assert test_name not in mast_aladin._overlays_dict
+    assert test_name + "_1" in mast_aladin._overlays_dict
+    assert region_overlay.name == updated_options["name"]
+    assert region_overlay.options["color"] == updated_options["color"]
+    assert region_overlay.options == updated_options
+
+
+test_stcs_iterables = [
+    "CIRCLE ICRS 258.93205686 43.13632863 0.625",
+]
+
+
+@pytest.mark.parametrize("stcs_strings", test_stcs_iterables)
+def test_overlays_dict_add_graphic_overlay_from_stcs_(
+    stcs_strings,
+):
+    """Test overlays_dict overlay info from adding iterable STC-S string(s).
+
+    Parameters
+    ----------
+    stcs_strings : Union[Iterable[str], str]
+        The stcs strings to create region overlay info from.
+
+    """
+    mast_aladin = MastAladin()
+
+    test_name = "test"
+    options = {"name": test_name, "color":"red"}
+    stcs_overlay = mast_aladin.add_graphic_overlay_from_stcs(stcs_strings, **options)
+
+    assert type(stcs_overlay) is MastOverlay
+    assert stcs_overlay.options == options
+
+    updated_options = options.copy()
+    updated_options.update(
+        {"name":test_name + "_1", "color": "#66FF00"}
+    )
+
+    stcs_overlay = mast_aladin.update_overlay(
+        stcs_overlay,
+        **updated_options,
+    )
+
+    assert test_name not in mast_aladin._overlays_dict
+    assert test_name + "_1" in mast_aladin._overlays_dict
+    assert stcs_overlay.name == updated_options["name"]
+    assert stcs_overlay.options["color"] == updated_options["color"]
+    assert stcs_overlay.options == updated_options

--- a/notebooks/Overlay_Update_Demo.ipynb
+++ b/notebooks/Overlay_Update_Demo.ipynb
@@ -8,9 +8,8 @@
    "outputs": [],
    "source": [
     "from mast_aladin_lite import MastAladin, AppSidecar\n",
-    "from astropy.coordinates import SkyCoord, Angle\n",
     "\n",
-    "# Initializing with target loc set using ipyaladin method\n",
+    "# Initializing with zoom to better see overlay\n",
     "mast_aladin = MastAladin(\n",
     "    zoom = 2,\n",
     ")\n",
@@ -44,7 +43,6 @@
     "        Marker(\n",
     "            position=name,\n",
     "            title=name,\n",
-    "            # the title and description can be written as plain text or as html elements\n",
     "            description=(\n",
     "                '<a href=\"https://simbad.cds.unistra.fr/simbad/'\n",
     "                f'sim-basic?Ident={name}&submit=SIMBAD+search\"> '\n",
@@ -53,7 +51,9 @@
     "        )\n",
     "    )\n",
     "mast_aladin.target = \"M1\"\n",
-    "marker_example = mast_aladin.add_markers(markers, name=\"M1-M10\", color=\"pink\", shape=\"cross\", source_size=15)\n",
+    "marker_example = mast_aladin.add_markers(\n",
+    "    markers, name=\"M1-M10\", color=\"pink\", shape=\"cross\", source_size=15\n",
+    ")\n",
     "print(mast_aladin._overlays_dict.keys())\n",
     "print(\"overlay name:\", marker_example.name)\n",
     "print(\"overlay type:\", marker_example.type)\n",
@@ -69,7 +69,9 @@
    "outputs": [],
    "source": [
     "# Update the color of the marker overlay, returns the updated MastOverlay\n",
-    "marker_example = marker_example.update(color = \"#66FF00\")"
+    "marker_example = marker_example.update(\n",
+    "    color = \"#66FF00\"\n",
+    ")"
    ]
   },
   {
@@ -79,8 +81,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Update the color, shape, and source size of the marker overlay, returns the updated MastOverlay\n",
-    "marker_example = marker_example.update(color = \"#04D9FF\", shape=\"o\", source_size = 30)"
+    "# Update the name, color, shape, and source size of the marker overlay, returns the updated MastOverlay\n",
+    "marker_example = marker_example.update(\n",
+    "    name = \"new_name\",\n",
+    "    color = \"#04D9FF\", \n",
+    "    shape = \"o\", \n",
+    "    source_size = 30\n",
+    ")"
    ]
   },
   {
@@ -91,7 +98,7 @@
    "outputs": [],
    "source": [
     "# Remove the overlay\n",
-    "mast_aladin.remove_overlay(\"M1-M10\")\n",
+    "mast_aladin.remove_overlay(\"new_name\")\n",
     "mast_aladin._overlays_dict.keys()"
    ]
   },

--- a/notebooks/Overlay_Update_Demo.ipynb
+++ b/notebooks/Overlay_Update_Demo.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64ece6f1-e55e-4b77-9a99-6b9fe6931cbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mast_aladin_lite import MastAladin, AppSidecar\n",
+    "from astropy.coordinates import SkyCoord, Angle\n",
+    "\n",
+    "# Initializing with target loc set using ipyaladin method\n",
+    "mast_aladin = MastAladin(\n",
+    "    zoom = 2,\n",
+    ")\n",
+    "\n",
+    "AppSidecar.open(mast_aladin, anchor = \"split-right\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f93333f-e425-4ba4-b16f-e8cb08614b0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mast_aladin._overlays_dict.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7441498d-6caa-4d01-ac3f-dcb42b2d5f8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add_markers demo\n",
+    "from ipyaladin import Marker\n",
+    "markers = []\n",
+    "for i in range(1, 11):\n",
+    "    name = f\"M{i}\"\n",
+    "    markers.append(\n",
+    "        Marker(\n",
+    "            position=name,\n",
+    "            title=name,\n",
+    "            # the title and description can be written as plain text or as html elements\n",
+    "            description=(\n",
+    "                '<a href=\"https://simbad.cds.unistra.fr/simbad/'\n",
+    "                f'sim-basic?Ident={name}&submit=SIMBAD+search\"> '\n",
+    "                \"Read more on SIMBAD</a>\"\n",
+    "            ),\n",
+    "        )\n",
+    "    )\n",
+    "mast_aladin.target = \"M1\"\n",
+    "marker_example = mast_aladin.add_markers(markers, name=\"M1-M10\", color=\"pink\", shape=\"cross\", source_size=15)\n",
+    "print(mast_aladin._overlays_dict.keys())\n",
+    "print(\"overlay name:\", marker_example.name)\n",
+    "print(\"overlay type:\", marker_example.type)\n",
+    "print(\"overlay options:\", marker_example.options)\n",
+    "print(\"overlay data info:\", marker_example.data.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d445ed5f-1ab0-41ce-9232-25c8edad86e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Update the color of the marker overlay, returns the updated MastOverlay\n",
+    "marker_example = marker_example.update(color = \"#66FF00\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9365f532-fc56-4134-b7cd-cc26381ba11b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Update the color, shape, and source size of the marker overlay, returns the updated MastOverlay\n",
+    "marker_example = marker_example.update(color = \"#04D9FF\", shape=\"o\", source_size = 30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a874fc15-919f-440a-bc4d-8f2fb3faba79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove the overlay\n",
+    "mast_aladin.remove_overlay(\"M1-M10\")\n",
+    "mast_aladin._overlays_dict.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd0c4f-f197-4f2e-8d14-871f88e74537",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR addresses [CST-295](https://jira.stsci.edu/browse/CST-295) and allows for users to update any `MastOverlay` they have added to the viewer. Below is an example for the `add_markers` overlay method, showing a user updating the color, updating the name/color/shape/size, and then deleting the overlay.

https://github.com/user-attachments/assets/88b69056-f7b7-454e-811c-609fde84f5c7

To update an overlay (e.g. `example_overlay = MastOverlay()`), users just call `example_overlay.update(** new_options)` with any options for the overlay they want to update. This is achieved by retrieving relevant information from the `MastOverlay`, deleting the original `MastOverlay`, updating any options passed by the user (name, color, shape, etc.), and finally adding the updated `MastOverlay`.

This PR includes a notebook demo (which is shown in the recording above) and tests for the new feature.