### PR TITLE
Region search notebook

### DIFF
--- a/notebooks/Region_Search_Overview.ipynb
+++ b/notebooks/Region_Search_Overview.ipynb
@@ -17,6 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from astropy import units as u\n",
     "from astroquery.mast import Observations\n",
     "from pyvo.dal import TAPService\n",
     "\n",
@@ -102,11 +103,12 @@
    "metadata": {},
    "source": [
     "### Helper Functions\n",
-    "The ADQL for a region query is a bit involved, so we'll provide some helper functions to make the region part of the query easier to construct.  They'll start out in this notebook, but belong somewhere else.\n",
+    "The ADQL for a region query is a bit involved, so we'll provide some helper functions to make the region part of the query easier to construct.  They'll start out in this notebook, but belong somewhere else like `MastAladin` or `astroquery`.\n",
     "\n",
-    "The user would typically call:\n",
+    "The user would typically call one of:\n",
     "\n",
-    "`perform_mast_reqion_query(region, other_clauses='', limit=50000)` \n",
+    "- `mast_reqion_query(region, other_clauses='', limit=50000)` \n",
+    "- `mast_region_query_aladin_fov(aladin, other_clauses='', limit=50000, show_query=True)`\n",
     "\n",
     "which would use the other two helper functions:\n",
     "- `create_mast_region_adql(region, other_clauses='', limit=50000)`\n",
@@ -164,7 +166,7 @@
     "    else:\n",
     "        # Assume we've got a list/sequence of points (lists/sequences)\n",
     "        point_string = ','.join([str(num) for point in region for num in point])\n",
-    "        aqql_region = f\"POLYGON('ICRS',{point_string})\"\n",
+    "        adql_region = f\"POLYGON('ICRS',{point_string})\"\n",
     "\n",
     "    return adql_region"
    ]
@@ -212,7 +214,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def perform_mast_reqion_query(region, other_clauses='', limit=50000, show_query=True):\n",
+    "def mast_reqion_query(region, other_clauses='', limit=50000, show_query=True):\n",
     "    \"\"\"\n",
     "    Query MAST observations over the specified region using the MAST CAOM TAP service.\n",
     "    \n",
@@ -237,7 +239,42 @@
     "    \n",
     "    results = mast_caom_tap_service.run_async(adql)\n",
     "    table_results = results.to_table()\n",
+    "    if show_query:\n",
+    "        print(f'Number of results: {len(table_results)}')\n",
+    "    \n",
     "    return table_results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b19f95ff-fa02-4775-95f3-ede9cbf46264",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mast_region_query_aladin_fov(aladin, other_clauses='', limit=50000, show_query=True):\n",
+    "    \"\"\"\n",
+    "    Query MAST observations over the FoV of the specified Aladin instance.  We won't do the\n",
+    "    search if Aladin's FoV is greater than 1 degree or its WCS doesn't exist for some reason.\n",
+    "    \n",
+    "    aladin - A MastAladin instance.\n",
+    "    other_clauses - ADQL to tack on to the end of the CAOM TAP obspointing query\n",
+    "    limit - max number of rows to return (default 50000)\n",
+    "\n",
+    "    Returns an astropy table of MAST observations much like astroquery.mast Observations queries.\n",
+    "    \"\"\"\n",
+    "    results = None\n",
+    "    \n",
+    "    # Don't do it if FoV is bigger than 1 degree.\n",
+    "    if aladin.fov > 1 * u.degree:\n",
+    "        print(f'FoV of {aladin.fov} is greater than the 1 degree limit.')\n",
+    "    elif aladin.wcs:\n",
+    "        footprint = aladin.wcs.calc_footprint()\n",
+    "        results = mast_reqion_query(footprint, other_clauses=other_clauses, limit=limit, show_query=show_query)\n",
+    "    else:\n",
+    "        print('Aladin WCS information not found')\n",
+    "\n",
+    "    return results"
    ]
   },
   {
@@ -315,8 +352,65 @@
     "AND project = 'HST'\n",
     "\"\"\"\n",
     "\n",
-    "hst_obs = perform_mast_reqion_query(footprint, other_clauses=other_clauses)\n",
+    "hst_obs = mast_reqion_query(footprint, other_clauses=other_clauses)\n",
     "hst_obs_layer = aladin.add_table(hst_obs, name='HST Observations', color='#FF6600')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f646fbe2-0574-422a-8ad3-53d26cbc60d2",
+   "metadata": {},
+   "source": [
+    "# Example: Search on Current Aladin FoV\n",
+    "Search on the polygon defined by Aladin's current viewport.  The polygon corners are computed using Aladin's notion of the WCS for the viewport.  We don't allow searches if the FoV is greater than 1 degree.\n",
+    "\n",
+    "We'll use the existing Aladin instance.\n",
+    "\n",
+    "## Search for HST on Current FoV."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "713a9213-f106-478b-ab55-785c119ad12a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Search MAST for HST observations that contain the current Aladin FoV.\n",
+    "other_clauses = \"\"\"\n",
+    "AND obs_collection = 'HST'\n",
+    "AND project = 'HST'\n",
+    "\"\"\"\n",
+    "hst_fov_obs = mast_region_query_aladin_fov(aladin, other_clauses=other_clauses)\n",
+    "\n",
+    "# Add the results in yellow.\n",
+    "hst_fov_obs_layer = aladin.add_table(hst_fov_obs, name='HST FoV Observations', color='yellow')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30059fd7-456e-4b13-903a-197d64b6b2b7",
+   "metadata": {},
+   "source": [
+    "## Search for TESS on Current FoV."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91992d20-2563-4bac-ae56-20f01bcb120b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Search MAST for TESS observations that contain the current Aladin FoV.\n",
+    "other_clauses = \"\"\"\n",
+    "AND obs_collection = 'TESS'\n",
+    "AND project = 'TESS'\n",
+    "\"\"\"\n",
+    "tess_fov_obs = mast_region_query_aladin_fov(aladin, other_clauses=other_clauses)\n",
+    "\n",
+    "# Add the results in blue.\n",
+    "tess_fov_obs_layer = aladin.add_table(tess_fov_obs, name='TESS FoV Observations', color='blue')"
    ]
   }
  ],


### PR DESCRIPTION
This notebook:
- describes how to do a region search in MAST via the CAOM VO TAP service. 
- shows how we might add helper routines for creating the somewhat weird ADQL for regions.
- shows 2 examples (so far)
  - searching a region defined by an observation's footprint
  - searching the current Aladin viewport/FoV