### PR TITLE
CST-457 Syncing to Imviz Rotation

### DIFF
--- a/mast_aladin/adapters/imviz_sync_adapter.py
+++ b/mast_aladin/adapters/imviz_sync_adapter.py
@@ -11,21 +11,18 @@ class ImvizSyncAdapter(ViewerSyncAdapter):
         self.state = self.viewer._obj.glue_viewer.state
 
     def add_callback(self, func):
-        try:
-            self.state.add_callback('x_min', func)
-        except Exception as e:
-            warnings.warn(f"Failed to add callback for 'x_min': {e}")
-
-        warnings.warn(
-            "Rotation syncing from Imviz → Mast-Aladin is currently disabled. "
-            "Changes in Imviz orientation will not propagate."
-        )
+        for name in ['x_min', 'reference_data']:
+            try:
+                self.state.add_callback(name, func)
+            except Exception as e:
+                warnings.warn(f"Failed to add callback {name}: {e}")
 
     def remove_callback(self, func):
-        try:
-            self.state.remove_callback('x_min', func)
-        except Exception as e:
-            warnings.warn(f"Failed to remove callback for 'x_min': {e}")
+        for name in ['x_min', 'reference_data']:
+            try:
+                self.state.remove_callback(name, func)
+            except Exception as e:
+                warnings.warn(f"Failed to remove callback {name}: {e}")
 
     def show(self):
         self.app.show()

--- a/mast_aladin/adapters/viewer_sync_ui.py
+++ b/mast_aladin/adapters/viewer_sync_ui.py
@@ -68,10 +68,6 @@ class ViewerSyncUI():
             self.sync_manager.stop_real_time_sync()
             return
 
-        self.rotation_button.disabled = False
-        if source == self.imviz:
-            self.rotation_button.disabled = True
-
         aspects = self._get_active_aspects()
         self.sync_manager.start_real_time_sync(
             source=source,


### PR DESCRIPTION
Updating the viewer sync to handle syncing to imviz's rotation following the PR in https://github.com/spacetelescope/jdaviz/pull/3914. The clip below shows that you can now observe changes made to rotation using the GUI (in addition to those made using AIDA!)

https://github.com/user-attachments/assets/8a57ee1b-ceca-4eba-9c05-9558e01f8e8e

