### PR TITLE
CST-552 limit number of overlay name warnings

### DIFF
--- a/mast_aladin/overlay/overlay_manager.py
+++ b/mast_aladin/overlay/overlay_manager.py
@@ -67,7 +67,7 @@ class OverlayManager:
         unique_name = self.make_unique_name(name=name)
         overlay_options["name"] = unique_name
 
-        if unique_name != name:
+        if unique_name != name and name != default_name:
             warnings.warn(
                 f"Overlayer name `{name}` is already in use. Name `{unique_name}` "
                 "will be used instead.",

--- a/mast_aladin/tests/test_overlays_dict.py
+++ b/mast_aladin/tests/test_overlays_dict.py
@@ -355,10 +355,8 @@ def test_existing_overlay_name(
     mast_aladin.add_graphic_overlay_from_stcs(stcs_strings)
 
     # name specified, warning triggered
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(match="is already in use. Name `test_1`"):
         mast_aladin.add_graphic_overlay_from_stcs(stcs_strings, name=test_name)
-        assert len(w) == 1
-        assert test_name + "_1" in str(w[-1].message)
 
     assert test_name in mast_aladin._overlays_dict
     assert "overlay_python" in mast_aladin._overlays_dict

--- a/mast_aladin/tests/test_overlays_dict.py
+++ b/mast_aladin/tests/test_overlays_dict.py
@@ -332,6 +332,40 @@ def test_invalid_overlay_type(
         MastOverlay(test_invalid_overlay, mast_aladin)
 
 
+@pytest.mark.parametrize("stcs_strings", test_stcs_iterables)
+def test_existing_overlay_name(
+    monkeypatch,
+    stcs_strings,
+):
+    """Test proper messages sent for existing overlays.
+
+    Parameters
+    ----------
+    stcs_strings : Union[Iterable[str], str]
+        The stcs strings to create region overlay info from.
+
+    """
+    test_name = "test"
+    mock_send = Mock()
+    monkeypatch.setattr(MastAladin, "send", mock_send)
+    mast_aladin.add_graphic_overlay_from_stcs(stcs_strings)
+    mast_aladin.add_graphic_overlay_from_stcs(stcs_strings, name=test_name)
+
+    # no name specified, no warning triggered
+    mast_aladin.add_graphic_overlay_from_stcs(stcs_strings)
+
+    # name specified, warning triggered
+    with warnings.catch_warnings(record=True) as w:
+        mast_aladin.add_graphic_overlay_from_stcs(stcs_strings, name=test_name)
+        assert len(w) == 1
+        assert test_name + "_1" in str(w[-1].message)
+
+    assert test_name in mast_aladin._overlays_dict
+    assert "overlay_python" in mast_aladin._overlays_dict
+    assert "overlay_python_1" in mast_aladin._overlays_dict
+    assert len(mast_aladin._overlays_dict.keys()) == 4
+
+
 test_marker_overlay = MastOverlay(
     {
         "type": "marker",


### PR DESCRIPTION
mast-aladin currently warns users about overlay names that must be different than the name they specified to maintain uniqueness. This PR updates the logic to warn the user only if they specify a name that is a duplicate (no warnings if the user does NOT specify a name and it becomes `default_name_#` like `catalog_python_1` etc)