### PR TITLE
Simplify add_asdf: allow Path-like argument, rely on file not found errors from roman_datamodels

### DIFF
--- a/mast_aladin/app.py
+++ b/mast_aladin/app.py
@@ -1,5 +1,4 @@
 import io
-import os
 
 from ipyaladin import Aladin
 from mast_table import MastTable
@@ -84,7 +83,7 @@ class MastAladin(Aladin, DelayUntilRendered):
 
         Parameters
         ----------
-        asdf : Union[str, rdd]
+        asdf : Union[str or Path-like, rdd]
             The ASDF image to load in the widget. It can be given as a path (either a
             string or as a `roman_datamodels.datamodels._datamodels.ImageModel`).
         image_options : any
@@ -92,29 +91,10 @@ class MastAladin(Aladin, DelayUntilRendered):
             <https://cds-astro.github.io/aladin-lite/global.html#ImageOptions>`_
 
         """
-
-        if isinstance(asdf, str):
-            if not os.path.exists(asdf):
-                raise ValueError(
-                    f"The file path given {asdf} does not exist, so no ASDF file "
-                    "can be loaded."
-                )
-
-            try:
-                asdf_file = rdd.open(asdf)
-            except Exception as e:
-                raise ValueError(
-                    f"Invalid Roman Datamodel ASDF structure in {asdf}. "
-                    "Ensure the file is accessible and a valid Roman Datamodel."
-                ) from e
-
-        elif isinstance(asdf, rdd._datamodels.ImageModel):
+        if isinstance(asdf, rdd._datamodels.ImageModel):
             asdf_file = asdf
         else:
-            raise TypeError(
-                "The provided ASDF was not given as a string or roman_datamodel, "
-                "so no ASDF file could be loaded."
-            )
+            asdf_file = rdd.open(asdf)
 
         wcs_header = fits.Header(asdf_file.meta.wcs.to_fits_sip())
 

--- a/mast_aladin/tests/test_add_asdf.py
+++ b/mast_aladin/tests/test_add_asdf.py
@@ -1,16 +1,11 @@
-import os
 import pytest
-import re
 import warnings
-import tempfile
-import gc
 
 import numpy as np
 import astropy.units as u
 from astropy.modeling import models
 from gwcs import coordinate_frames as cf, wcs as gwcs_wcs
 from astropy.coordinates import ICRS
-import asdf
 
 
 def create_example_gwcs(shape):
@@ -103,42 +98,3 @@ def test_image_options(MastAladin_app, roman_imagemodel):
     with warnings.catch_warnings(record=True) as w:
         MastAladin_app.add_asdf(roman_imagemodel, name="test", colormap="viridis")
         assert len(w) == 0
-
-
-def test_invalid_filepath(MastAladin_app):
-    """Test add_asdf raises error for invalid filepaths."""
-
-    invalid_filepath = os.path.join(
-        os.path.dirname(__file__), "data", "this_is_fake.asdf"
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            f"The file path given {invalid_filepath} does not exist, so no ASDF file "
-            "can be loaded."
-        )
-    ):
-        MastAladin_app.add_asdf(invalid_filepath)
-
-
-def test_invalid_asdf(MastAladin_app):
-    """Test add_asdf raises error for invalid ASDF file."""
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        invalid_asdf_filepath = tmp_dir + "/invalid.asdf"
-        tree = {'hst': 'fantastic', 'jwst': 'phenomenal'}
-        with asdf.AsdfFile(tree) as f:
-            f.write_to(invalid_asdf_filepath)
-
-        with pytest.raises(
-            ValueError,
-            match=re.escape(
-                f"Invalid Roman Datamodel ASDF structure in {invalid_asdf_filepath}. "
-                "Ensure the file is accessible and a valid Roman Datamodel."
-            )
-        ):
-            MastAladin_app.add_asdf(invalid_asdf_filepath)
-
-        del f
-        gc.collect()


### PR DESCRIPTION
`MastAladin.add_asdf` only allows `isinstance(asdf_path, str)` or `isinstance(asdf_path, ImageModel)`. Folks commonly pass around paths as `pathlib.Path` objects, which aren't permitted in the current method. 

The `add_asdf` method needs to be less strict because `astroquery.mast.MissionMast.download_product` returns product file paths as `Path` objects.

This PR relies on more Pythonic duck typing to open the file. If the file can't be opened, we allow `roman_datamodels` (or `asdf` within rdm) to raise their own errors, rather than wrapping them with our own.