### PR TITLE
CST-639 handling SIP in fits files

### DIFF
--- a/mast_aladin/app.py
+++ b/mast_aladin/app.py
@@ -153,13 +153,12 @@ class MastAladin(Aladin, DelayUntilRendered):
 
         """
 
-        # Wraps add_fits in ipyaladin to temporarily handle "SIP" .
+        # Wraps add_fits in ipyaladin to temporarily handle SIP.
         # See ipyaladin for definitions of parameters.
 
         is_path = isinstance(f, (Path, str))
         if is_path:
             with fits.open(f) as fits_file:
-                fits_bytes = io.BytesIO()
                 for hdu in fits_file:
                     if hdu.data is not None:
                         wcs_header = hdu.header
@@ -178,7 +177,6 @@ class MastAladin(Aladin, DelayUntilRendered):
                         )
                     ]
                 )
-                hdu_list.writeto(fits_bytes)
         else:
             hdu_list = f
 

--- a/mast_aladin/app.py
+++ b/mast_aladin/app.py
@@ -12,6 +12,7 @@ from regions import (
     PolygonSkyRegion
 )
 from pathlib import Path
+from astropy.wcs import WCS
 
 from mast_aladin.aida import AID
 from mast_aladin.mixins import DelayUntilRendered
@@ -122,8 +123,6 @@ class MastAladin(Aladin, DelayUntilRendered):
             )
 
         wcs_header = fits.Header(asdf_file.meta.wcs.to_fits()[0])
-        wcs_header["CTYPE1"] = "RA---TAN"
-        wcs_header["CTYPE2"] = "DEC--TAN"
 
         hdu_list = fits.HDUList(
             [
@@ -158,32 +157,35 @@ class MastAladin(Aladin, DelayUntilRendered):
 
         is_path = isinstance(f, (Path, str))
         if is_path:
-            with fits.open(f) as fits_file:
-                for hdu in fits_file:
-                    data = hdu.data
-                    if data is not None:
-                        wcs_header = hdu.header
-                        break
-
-                if data is None:
-                    raise ValueError(
-                        f"No FITS image in {f}. Ensure the file is a valid FITS image."
-                    )
-
-                wcs_header["CTYPE1"] = "RA---TAN"
-                wcs_header["CTYPE2"] = "DEC--TAN"
-
-                hdu_list = fits.HDUList(
-                    [
-                        fits.PrimaryHDU(header=wcs_header),
-                        fits.ImageHDU(
-                            header=wcs_header,
-                            data=data
-                        )
-                    ]
-                )
+            fits_file = fits.open(f)
         else:
-            hdu_list = f
+            fits_file = f
+
+        for hdu in fits_file:
+            data = hdu.data
+            if data is not None:
+                wcs = WCS(hdu.header)
+                break
+
+        if data is None:
+            raise ValueError(
+                "No FITS image in the data. Ensure the file is a valid FITS image."
+            )
+
+        if wcs.sip is not None:
+            wcs.sip = None
+
+        wcs_header = wcs.to_header()
+
+        hdu_list = fits.HDUList(
+            [
+                fits.PrimaryHDU(header=wcs_header),
+                fits.ImageHDU(
+                    header=wcs_header,
+                    data=data
+                )
+            ]
+        )
 
         super().add_fits(hdu_list, **image_options)
 

--- a/mast_aladin/app.py
+++ b/mast_aladin/app.py
@@ -137,7 +137,7 @@ class MastAladin(Aladin, DelayUntilRendered):
         self.add_fits(hdu_list, **image_options)
 
     def add_fits(
-        self, f, extension = 1, **image_options
+        self, f, extension=1, **image_options
     ):
         """Load a FITS image into the widget.
 

--- a/mast_aladin/app.py
+++ b/mast_aladin/app.py
@@ -160,10 +160,15 @@ class MastAladin(Aladin, DelayUntilRendered):
         if is_path:
             with fits.open(f) as fits_file:
                 for hdu in fits_file:
-                    if hdu.data is not None:
+                    data = hdu.data
+                    if data is not None:
                         wcs_header = hdu.header
-                        data = hdu.data
                         break
+
+                if data is None:
+                    raise ValueError(
+                        f"No FITS image in {f}. Ensure the file is a valid FITS image."
+                    )
 
                 wcs_header["CTYPE1"] = "RA---TAN"
                 wcs_header["CTYPE2"] = "DEC--TAN"

--- a/mast_aladin/app.py
+++ b/mast_aladin/app.py
@@ -137,7 +137,7 @@ class MastAladin(Aladin, DelayUntilRendered):
         self.add_fits(hdu_list, **image_options)
 
     def add_fits(
-        self, f, **image_options
+        self, f, extension = 1, **image_options
     ):
         """Load a FITS image into the widget.
 
@@ -146,6 +146,8 @@ class MastAladin(Aladin, DelayUntilRendered):
         f : Union[str, Path, HDUList]
             The FITS image to load in the widget. It can be given as a path (either a
             string or a `pathlib.Path` object), or as an `astropy.io.fits.HDUList`.
+        extension: int, optional
+            FITS extension containing the image data to load. Default is 1.
         image_options : any
             The options for the image. See the `Aladin Lite image options
             <https://cds-astro.github.io/aladin-lite/global.html#ImageOptions>`_
@@ -161,19 +163,18 @@ class MastAladin(Aladin, DelayUntilRendered):
         else:
             fits_file = f
 
-        for hdu in fits_file:
-            data = hdu.data
-            if data is not None:
-                wcs = WCS(hdu.header)
-                break
+        if len(fits_file) == 1:
+            extension = 0
+
+        data = fits_file[extension].data
+        wcs = WCS(fits_file[extension].header)
 
         if data is None:
             raise ValueError(
-                "No FITS image in the data. Ensure the file is a valid FITS image."
+                f"No data in extension {extension}."
             )
 
-        if wcs.sip is not None:
-            wcs.sip = None
+        wcs.sip = None
 
         wcs_header = wcs.to_header()
 

--- a/mast_aladin/app.py
+++ b/mast_aladin/app.py
@@ -11,6 +11,7 @@ from regions import (
     Regions,
     PolygonSkyRegion
 )
+from pathlib import Path
 
 from mast_aladin.aida import AID
 from mast_aladin.mixins import DelayUntilRendered
@@ -135,6 +136,53 @@ class MastAladin(Aladin, DelayUntilRendered):
         )
 
         self.add_fits(hdu_list, **image_options)
+
+    def add_fits(
+        self, f, **image_options
+    ):
+        """Load a FITS image into the widget.
+
+        Parameters
+        ----------
+        f : Union[str, Path, HDUList]
+            The FITS image to load in the widget. It can be given as a path (either a
+            string or a `pathlib.Path` object), or as an `astropy.io.fits.HDUList`.
+        image_options : any
+            The options for the image. See the `Aladin Lite image options
+            <https://cds-astro.github.io/aladin-lite/global.html#ImageOptions>`_
+
+        """
+
+        # Wraps add_fits in ipyaladin to temporarily handle "SIP" .
+        # See ipyaladin for definitions of parameters.
+
+        is_path = isinstance(f, (Path, str))
+        if is_path:
+            with fits.open(f) as fits_file:
+                fits_bytes = io.BytesIO()
+                for hdu in fits_file:
+                    if hdu.data is not None:
+                        wcs_header = hdu.header
+                        data = hdu.data
+                        break
+
+                wcs_header["CTYPE1"] = "RA---TAN"
+                wcs_header["CTYPE2"] = "DEC--TAN"
+
+                hdu_list = fits.HDUList(
+                    [
+                        fits.PrimaryHDU(header=wcs_header),
+                        fits.ImageHDU(
+                            header=wcs_header,
+                            data=data
+                        )
+                    ]
+                )
+                hdu_list.writeto(fits_bytes)
+        else:
+            hdu_list = f
+
+        super().add_fits(hdu_list, **image_options)
 
     def add_markers(
         self, markers, **catalog_options

--- a/mast_aladin/tests/test_add_fits.py
+++ b/mast_aladin/tests/test_add_fits.py
@@ -1,0 +1,110 @@
+import pytest
+import re
+import warnings
+
+import numpy as np
+from astropy.io import fits
+from astropy.wcs import WCS
+
+
+def create_wcs():
+    w = WCS(naxis=2)
+    w.wcs.crpix = [5, 5]
+    w.wcs.cdelt = [-0.000277, 0.000277]
+    w.wcs.crval = [0, 0]
+    w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    return w
+
+
+def create_example_fits():
+    data = np.ones((10, 10))
+
+    w = create_wcs()
+    wcs_header = w.to_header(relax=True)
+
+    hdu_list = fits.HDUList([
+        fits.PrimaryHDU(header=wcs_header),
+        fits.ImageHDU(data=data, header=wcs_header)
+    ])
+    return hdu_list
+
+
+def create_example_fits_with_sip():
+    data = np.ones((10, 10))
+
+    w = create_wcs()
+    w.wcs.ctype = ["RA---TAN-SIP", "DEC--TAN-SIP"]
+
+    # fake SIP terms
+    from astropy.wcs import Sip
+    A = np.zeros((3, 3))
+    B = np.zeros((3, 3))
+    Ap = np.zeros((3, 3))
+    Bp = np.zeros((3, 3))
+    w.sip = Sip(A, B, Ap, Bp, w.wcs.crpix)
+
+    wcs_header = w.to_header(relax=True)
+
+    hdu_list = fits.HDUList([
+        fits.PrimaryHDU(),
+        fits.ImageHDU(data=data, header=wcs_header)
+    ])
+
+    return hdu_list
+
+
+def create_empty_fits():
+
+    hdu_list = fits.HDUList([
+        fits.PrimaryHDU(),
+    ])
+    return hdu_list
+
+
+@pytest.fixture
+def fits_no_sip():
+    return create_example_fits()
+
+
+@pytest.fixture
+def fits_with_sip():
+    return create_example_fits_with_sip()
+
+
+@pytest.fixture
+def fits_empty():
+    return create_empty_fits()
+
+
+def test_add_fits(MastAladin_app, fits_no_sip):
+    """Test add_fits raises no warnings for valid fits."""
+
+    with warnings.catch_warnings(record=True) as w:
+        MastAladin_app.add_fits(fits_no_sip)
+        assert len(w) == 0
+
+
+def test_fits_with_sip(MastAladin_app, fits_with_sip):
+    """Test add_fits raises no warning for valid fits with sip."""
+
+    with warnings.catch_warnings(record=True) as w:
+        MastAladin_app.add_fits(fits_with_sip)
+        assert len(w) == 0
+
+
+def test_empty_fits(MastAladin_app, fits_empty):
+    """Test add_fits raises ValueError for empty fits."""
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("No FITS image")
+    ):
+        MastAladin_app.add_fits(fits_empty)
+
+
+def test_image_options(MastAladin_app, fits_no_sip):
+    """Test add_fits with image options raises no warnings for valid fits."""
+
+    with warnings.catch_warnings(record=True) as w:
+        MastAladin_app.add_fits(fits_no_sip, name="test", colormap="viridis")
+        assert len(w) == 0

--- a/mast_aladin/tests/test_add_fits.py
+++ b/mast_aladin/tests/test_add_fits.py
@@ -97,7 +97,7 @@ def test_empty_fits(MastAladin_app, fits_empty):
 
     with pytest.raises(
         ValueError,
-        match=re.escape("No FITS image")
+        match=re.escape("No data in extension 0")
     ):
         MastAladin_app.add_fits(fits_empty)
 


### PR DESCRIPTION
Adding in handling for SIP in calibrated fits files, as we did for asdf files. Currently, calibrated fits files do not properly load in ipyaladin. Temporarily dealing with this in a wrapper in mast-aladin while opening an issue in aladin-lite (since adding calibrated files via the GUI will still fail). Like asdf files, they contain SIP (Simple Imaging Polynomial) in the headers, which let you include 2D polynomial distortion. This is not currently handled in aladin-lite, and it is only present in calibrated fits files (uncalibrated files still load). There is no significant difference from stripping out the "SIP" in the ctype, which then allows the current aladin-lite FITS wcs package to process as though the header does not contain SIP info.

Can confirm functionality by running ./examples/demo-select-MAST-products.ipynb