### PR TITLE
Updating codecov-action version

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -101,7 +101,7 @@ jobs:
         merge-multiple: true
     - name: Upload report to Codecov
       if: ${{ hashFiles('coverage/') != '' }}
-      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: coverage


### PR DESCRIPTION
bumping codecov-action version to address failures from gpg verification, RE https://github.com/codecov/codecov-action/issues/1956