### PR TITLE
updates to the viewer sync UI

### DIFF
--- a/mast_aladin/adapters/viewer_sync_ui.py
+++ b/mast_aladin/adapters/viewer_sync_ui.py
@@ -13,10 +13,10 @@ class ViewerSyncUI():
         self.aspects = self.sync_manager.aspects
 
         self.viewer_buttons = widgets.ToggleButtons(
-            options=['None', 'Imviz', 'Mast Aladin'],
+            options=['None', 'Jdaviz', 'Mast Aladin'],
             disabled=False,
             button_style='',
-            tooltips=['No Syncing', 'Sync to Imviz', 'Sync to Mast Aladin'],
+            tooltips=['No Syncing', 'Sync to Jdaviz', 'Sync to Mast Aladin'],
             style=widgets.ToggleButtonsStyle(button_width="24%")
         )
 
@@ -42,7 +42,7 @@ class ViewerSyncUI():
     def _current_sync_direction(self):
         """Return (source, destination) tuple or (None, None)."""
         match self.viewer_buttons.value:
-            case "Imviz":
+            case "Jdaviz":
                 return self.imviz, self.mast_aladin
             case "Mast Aladin":
                 return self.mast_aladin, self.imviz
@@ -68,8 +68,8 @@ class ViewerSyncUI():
             self.sync_manager.stop_real_time_sync()
             return
 
-        # imviz does not currently support setting projection, so we disable the projection
-        # syncing option when imviz is the destintation
+        # Jdaviz does not currently support setting projection, so we disable the projection
+        # syncing option when Jdaviz is the destintation
         if dest == self.imviz:
             self.projection_button.value = False
             self.projection_button.disabled = True

--- a/mast_aladin/adapters/viewer_sync_ui.py
+++ b/mast_aladin/adapters/viewer_sync_ui.py
@@ -89,36 +89,39 @@ class ViewerSyncUI():
             "font-size: 12px; "
             "font-weight: 600; "
         )
-        
+
         viewer_target_label = widgets.HTML(
             f"<div style='{header_style}'>Source Widget</div>"
         )
-        
+
         sync_properties_label = widgets.HTML(
             f"<div style='{header_style}'>Properties</div>"
         )
-        
+
         properties_row_1 = widgets.HBox([
             self.center_button,
             self.fov_button
         ], layout=widgets.Layout(width="100%", gap="12px", margin="0"))
-        
+
         properties_row_2 = widgets.HBox([
             self.rotation_button,
             self.projection_button
         ], layout=widgets.Layout(width="100%", gap="12px", margin="0"))
-        
 
-        container = widgets.VBox([
+        contents = [
             viewer_target_label,
             self.viewer_buttons,
             sync_properties_label,
             properties_row_1,
             properties_row_2,
-        ], layout=widgets.Layout(
-            width="100%",
-            padding="20px",
-            border="1px solid"
-        ))
-        
+        ]
+        container = widgets.VBox(
+            contents,
+            layout=widgets.Layout(
+                width="100%",
+                padding="20px",
+                border="1px solid"
+            )
+        )
+
         display(container)

--- a/mast_aladin/adapters/viewer_sync_ui.py
+++ b/mast_aladin/adapters/viewer_sync_ui.py
@@ -85,17 +85,40 @@ class ViewerSyncUI():
         )
 
     def display(self):
-        self.imviz.layout = widgets.Layout(width="70%", height="100px")
-        self.mast_aladin.layout = widgets.Layout(width="70%", height="100px")
-
-        self.imviz.show()
-        display(self.viewer_buttons)
-        display(
-            widgets.HBox([
-                self.center_button,
-                self.fov_button,
-                self.rotation_button,
-                self.projection_button
-            ])
+        header_style = (
+            "font-size: 12px; "
+            "font-weight: 600; "
         )
-        self.mast_aladin.show()
+        
+        viewer_target_label = widgets.HTML(
+            f"<div style='{header_style}'>Source Widget</div>"
+        )
+        
+        sync_properties_label = widgets.HTML(
+            f"<div style='{header_style}'>Properties</div>"
+        )
+        
+        properties_row_1 = widgets.HBox([
+            self.center_button,
+            self.fov_button
+        ], layout=widgets.Layout(width="100%", gap="12px", margin="0"))
+        
+        properties_row_2 = widgets.HBox([
+            self.rotation_button,
+            self.projection_button
+        ], layout=widgets.Layout(width="100%", gap="12px", margin="0"))
+        
+
+        container = widgets.VBox([
+            viewer_target_label,
+            self.viewer_buttons,
+            sync_properties_label,
+            properties_row_1,
+            properties_row_2,
+        ], layout=widgets.Layout(
+            width="100%",
+            padding="20px",
+            border="1px solid"
+        ))
+        
+        display(container)

--- a/notebooks/view_sync_example.ipynb
+++ b/notebooks/view_sync_example.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "6cb18101-44bf-4cb5-a907-f8b45f9baf84",
    "metadata": {},
    "outputs": [],
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "31d177a1-7643-47ee-9385-b3d7c487d333",
    "metadata": {},
    "outputs": [],
@@ -42,22 +42,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "9da06bbe-4dcc-44c2-8002-8278c45bde0d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(<mast_aladin.app.MastAladin object at 0x4ec342ad0>,\n",
-       " <jdaviz.configs.deconfigged.helper.App at 0x4ec342fd0>)"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "AppSidecar.open(aladin_viewer, include_jdaviz=True, anchor=['split-right', 'split-bottom'])"
    ]
@@ -73,19 +61,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "6d693da8-dec5-4a31-a19c-86629441293f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO: Found cached file ./jw02727-o002_t062_nircam_clear-f090w_i2d.fits with expected size 626256000. [astroquery.query]\n",
-      "INFO: Found cached file ./jw02727-o002_t062_nircam_clear-f277w_i2d.fits with expected size 144118080. [astroquery.query]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "filenames = [\n",
     "    'jw02727-o002_t062_nircam_clear-f090w_i2d.fits',\n",
@@ -118,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "6ce175cb-d4ac-493e-9e6d-5aa1837f9dbe",
    "metadata": {
     "editable": true,
@@ -127,22 +106,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ec8b0431e4cd4f8f81837596285e996d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(HTML(value=\"<div style='font-size: 12px; font-weight: 600; '>Source Widget</div>\"), ToggleButto…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ui = ViewerSyncUI()\n",
     "ui.display()"
@@ -159,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "c98ca6de-ade2-4c2e-9877-aba784e8a266",
    "metadata": {},
    "outputs": [],

--- a/notebooks/view_sync_example.ipynb
+++ b/notebooks/view_sync_example.ipynb
@@ -17,13 +17,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "6cb18101-44bf-4cb5-a907-f8b45f9baf84",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mast_aladin import MastAladin\n",
+    "from mast_aladin import MastAladin, AppSidecar\n",
     "from mast_aladin.adapters import ViewerSyncUI\n",
+    "\n",
     "import jdaviz\n",
     "\n",
     "import warnings"
@@ -31,12 +32,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "31d177a1-7643-47ee-9385-b3d7c487d333",
    "metadata": {},
    "outputs": [],
    "source": [
     "aladin_viewer = MastAladin(target=\"Cartwheel Galaxy\", height=500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9da06bbe-4dcc-44c2-8002-8278c45bde0d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(<mast_aladin.app.MastAladin object at 0x4ec342ad0>,\n",
+       " <jdaviz.configs.deconfigged.helper.App at 0x4ec342fd0>)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "AppSidecar.open(aladin_viewer, include_jdaviz=True, anchor=['split-right', 'split-bottom'])"
    ]
   },
   {
@@ -50,10 +73,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "6d693da8-dec5-4a31-a19c-86629441293f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: Found cached file ./jw02727-o002_t062_nircam_clear-f090w_i2d.fits with expected size 626256000. [astroquery.query]\n",
+      "INFO: Found cached file ./jw02727-o002_t062_nircam_clear-f277w_i2d.fits with expected size 144118080. [astroquery.query]\n"
+     ]
+    }
+   ],
    "source": [
     "filenames = [\n",
     "    'jw02727-o002_t062_nircam_clear-f090w_i2d.fits',\n",
@@ -72,8 +104,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "515b134f-5a99-4f68-989b-dfe926f0d6d0",
+   "metadata": {},
+   "source": [
+    "### Viewer Sync UI\n",
+    "\n",
+    "The Viewer Sync UI enables real-time synchronization between viewers. The UI provides the following configuration setttings:\n",
+    "\n",
+    "- **Source Widget**: Select which viewer acts as the source of truth for the viewport (Imviz or Mast Aladin). Set to \"None\" to stop syncing.\n",
+    "- **Properties**: Choose which viewport properties to sync across viewers (Center, Field of View, Rotation, Projection)."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "6ce175cb-d4ac-493e-9e6d-5aa1837f9dbe",
    "metadata": {
     "editable": true,
@@ -82,7 +127,22 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ec8b0431e4cd4f8f81837596285e996d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HTML(value=\"<div style='font-size: 12px; font-weight: 600; '>Source Widget</div>\"), ToggleButto…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "ui = ViewerSyncUI()\n",
     "ui.display()"
@@ -99,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "c98ca6de-ade2-4c2e-9877-aba784e8a266",
    "metadata": {},
    "outputs": [],
@@ -132,7 +192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What is changing?
updates to the viewer sync UI

## Why is this change required?
As we started working on the "how to..." notebook for viewer syncing we were reminded of the state of the viewer sync UI. This PR makes updates to that UI in two main ways
1. We no longer open `mast-aladin` and `jdaviz` as part of displaying the UI. This made working with the tool challenging and is redundant given sidecar adoption
2. We added simple titles to the `source widget` and `properties` sections of the UI so that users have an indication as to what the buttons do 

In addition, we updated the `viewer_sync_example.ipynb` notebook to reflect these changes, specifically to utilize sidecar for the displaying of `mast-aladin` and `jdaviz`

Note: This is by no means the finished UI and is next stage MVP that enables the development of the "how to" notebook for viewer syncing

## Screenshots
<img width="2096" height="1245" alt="viewer_sync_ui_6_26" src="https://github.com/user-attachments/assets/9eaec089-7b80-4aed-88b1-b5a520ced4d6" />
