### PR TITLE
Move AIDA methods into mixin class for MastAladin

### DIFF
--- a/mast_aladin/adapters/aladin_sync_adapter.py
+++ b/mast_aladin/adapters/aladin_sync_adapter.py
@@ -7,7 +7,6 @@ from .viewer_sync_adapter import ViewerSyncAdapter
 class AladinSyncAdapter(ViewerSyncAdapter):
     def __init__(self, viewer=None):
         self.viewer = viewer if viewer else gca()
-        self.aid = self.viewer.aid
 
     def add_callback(self, func):
         self.viewer.observe(func, names=["_target", "_fov", "_rotation", "_projection"])

--- a/mast_aladin/adapters/imviz_sync_adapter.py
+++ b/mast_aladin/adapters/imviz_sync_adapter.py
@@ -21,6 +21,10 @@ class ImvizSyncAdapter(ViewerSyncAdapter):
             )
 
         self.viewer = self.app.viewers[glue_viewer._ref_or_id]
+
+        # TODO (2026-07-22): the jdaviz glue viewer attribute `aid`
+        # will be removed in a PR coming soon, the line below will
+        # need to be updated.
         self.aid = glue_viewer.aid
         self.state = glue_viewer.state
 

--- a/mast_aladin/adapters/viewer_sync_adapter.py
+++ b/mast_aladin/adapters/viewer_sync_adapter.py
@@ -3,14 +3,23 @@ from mast_aladin.aida import AIDA_aspects
 
 
 class ViewerSyncAdapter(ABC):
-    def sync_to(self, sync_viewer, aspects):
-        source_viewport = sync_viewer.aid.get_viewport(sky_or_pixel="sky")
+    def sync_to(self, sync_adapter, aspects):
 
-        new_viewport = self.aid.get_viewport(sky_or_pixel="sky").copy()
+        # TODO (2026-07-22): the jdaviz glue viewer attribute `aid`
+        # will be removed in a PR coming soon, the line below will
+        # need to be updated.
+        viewer = sync_adapter.viewer
+        if hasattr(sync_adapter, 'aid'):
+            # temporarily, the jdaviz sync adapter has an `aid attribute`
+            viewer = sync_adapter.aid
+
+        source_viewport = viewer.get_viewport(sky_or_pixel="sky")
+
+        new_viewport = viewer.get_viewport(sky_or_pixel="sky").copy()
         for aspect in set(aspects) & {*AIDA_aspects}:
             new_viewport[aspect] = source_viewport[aspect]
 
-        self.aid.set_viewport(**new_viewport)
+        viewer.set_viewport(**new_viewport)
 
     @abstractmethod
     def add_callback(self, func):

--- a/mast_aladin/adapters/viewer_sync_adapter.py
+++ b/mast_aladin/adapters/viewer_sync_adapter.py
@@ -3,23 +3,28 @@ from mast_aladin.aida import AIDA_aspects
 
 
 class ViewerSyncAdapter(ABC):
-    def sync_to(self, sync_adapter, aspects):
+    def sync_to(self, sync_viewer, aspects):
+        source_viewer = sync_viewer.viewer
 
         # TODO (2026-07-22): the jdaviz glue viewer attribute `aid`
         # will be removed in a PR coming soon, the line below will
         # need to be updated.
-        viewer = sync_adapter.viewer
-        if hasattr(sync_adapter, 'aid'):
-            # temporarily, the jdaviz sync adapter has an `aid attribute`
-            viewer = sync_adapter.aid
+        if hasattr(source_viewer, '_obj'):
+            source_viewer = source_viewer._obj.glue_viewer.aid
 
-        source_viewport = viewer.get_viewport(sky_or_pixel="sky")
+        source_viewport = source_viewer.get_viewport(sky_or_pixel="sky")
 
-        new_viewport = viewer.get_viewport(sky_or_pixel="sky").copy()
+        new_viewport = source_viewer.get_viewport(sky_or_pixel="sky").copy()
         for aspect in set(aspects) & {*AIDA_aspects}:
             new_viewport[aspect] = source_viewport[aspect]
 
-        viewer.set_viewport(**new_viewport)
+        # TODO (2026-07-22): the jdaviz glue viewer attribute `aid`
+        # will be removed in a PR coming soon, the line below will
+        # need to be updated.
+        if hasattr(self.viewer, '_obj'):
+            self.viewer._obj.glue_viewer.aid.set_viewport(**new_viewport)
+        else:
+            self.viewer.set_viewport(**new_viewport)
 
     @abstractmethod
     def add_callback(self, func):

--- a/mast_aladin/aida.py
+++ b/mast_aladin/aida.py
@@ -12,9 +12,9 @@ class AIDA_aspects(StrEnum):
     PROJECTION = "projection"
 
 
-class AID:
+class AIDA:
     """
-    Provides API for mast-aladin to allow for parity with
+    Provides a mixin API for mast-aladin to allow for parity with
     jdaviz. This is to be used as a mixin within exisiting classes.
     This is based on the Astro Image Display API (AIDA)[1]_.
 
@@ -23,10 +23,6 @@ class AID:
     .. [1] https://github.com/astropy/astro-image-display-api/
 
     """
-
-    def __init__(self, mast_aladin):
-        self.app = mast_aladin
-
     def _set_center(self, center=None):
         if center is None:
             return
@@ -36,7 +32,7 @@ class AID:
                 f"`center` must be a SkyCoord object. Received {center=}"
             )
 
-        self.app.target = center
+        self.target = center
 
     def _set_fov(self, fov=None):
         if fov is None:
@@ -52,8 +48,8 @@ class AID:
 
         # Determine the scale factor by which we want to adjust setting the
         # ipyaladin horizontal fov
-        scale_factor = fov / min(self.app.fov_xy)
-        self.app.fov = self.app.fov * scale_factor
+        scale_factor = fov / min(self.fov_xy)
+        self.fov = self.fov * scale_factor
 
     def _set_rotation(self, rotation=None):
         if rotation is None:
@@ -67,13 +63,13 @@ class AID:
         if isinstance(rotation, (u.Quantity, Angle)):
             rotation = rotation.to_value(u.deg)
 
-        self.app.rotation = rotation
+        self.rotation = rotation
 
     def _set_projection(self, projection=None):
         if projection is None:
             return
 
-        self.app.projection = projection
+        self.projection = projection
 
     def set_viewport(
         self,
@@ -183,10 +179,10 @@ class AID:
             )
 
         viewport_state = dict(
-            center=self.app.target,
-            fov=min(self.app.fov_xy),
-            rotation=self.app.rotation,
-            projection=self.app.projection,
+            center=self.target,
+            fov=min(self.fov_xy),
+            rotation=self.rotation,
+            projection=self.projection,
             image_label=None
         )
 

--- a/mast_aladin/app.py
+++ b/mast_aladin/app.py
@@ -9,7 +9,7 @@ from regions import (
 from pathlib import Path
 from astropy.wcs import WCS
 
-from mast_aladin.aida import AID
+from mast_aladin.aida import AIDA
 from mast_aladin.mixins import DelayUntilRendered
 
 import roman_datamodels.datamodels as rdd
@@ -23,7 +23,7 @@ __all__ = [
 _latest_instantiated_app = None
 
 
-class MastAladin(Aladin, DelayUntilRendered):
+class MastAladin(Aladin, DelayUntilRendered, AIDA):
     """
     An Aladin-lite widget with enhanced support for
     datasets from `MAST <https://mast.stsci.edu/>`_, built on
@@ -35,10 +35,6 @@ class MastAladin(Aladin, DelayUntilRendered):
         kwargs.setdefault('coo_frame', 'ICRSd')
 
         super().__init__(*args, **kwargs)
-
-        # the `aid` attribute gives access to methods from the
-        # Astro Image Display (AID) API
-        self.aid = AID(self)
 
         global _latest_instantiated_app
         _latest_instantiated_app = self

--- a/mast_aladin/tests/adapters/test_sync_adapters.py
+++ b/mast_aladin/tests/adapters/test_sync_adapters.py
@@ -18,7 +18,7 @@ class TestSyncAdapters(BaseImviz):
         imviz_sync_adapter = ImvizSyncAdapter()
 
         # assert starting coordinate is approximately on Cartwheel Galaxy
-        center = mast_aladin_sync_adapter.aid.get_viewport()[AIDA_aspects.CENTER]
+        center = mast_aladin_sync_adapter.viewer.get_viewport()[AIDA_aspects.CENTER]
         assert center.ra.deg == approx(9.4213055, rel=1e-8)
         assert center.dec.deg == approx(-33.71625419, rel=1e-8)
 
@@ -27,6 +27,10 @@ class TestSyncAdapters(BaseImviz):
 
         # assert that the view has changed as expected
         center = mast_aladin_sync_adapter.viewer.target
+
+        # TODO (2026-07-22): the jdaviz glue viewer attribute `aid`
+        # will be removed in a PR coming soon, the line below will
+        # need to be updated.
         imviz_center = imviz_sync_adapter.aid.get_viewport()["center"]
         assert center.ra.deg == approx(imviz_center.ra.deg, rel=1e-8)
         assert center.dec.deg == approx(imviz_center.dec.deg, rel=1e-8)
@@ -41,6 +45,9 @@ class TestSyncAdapters(BaseImviz):
         imviz_sync_adapter = ImvizSyncAdapter()
 
         # assert starting coordinate is approximately on Cartwheel Galaxy
+        # TODO (2026-07-22): the jdaviz glue viewer attribute `aid`
+        # will be removed in a PR coming soon, the line below will
+        # need to be updated.
         center = imviz_sync_adapter.aid.get_viewport(sky_or_pixel="sky")[AIDA_aspects.CENTER]
         assert center.ra.deg == approx(9.425937637864708, rel=1e-8)
         assert center.dec.deg == approx(-33.71515927986813, rel=1e-8)
@@ -49,7 +56,10 @@ class TestSyncAdapters(BaseImviz):
         imviz_sync_adapter.sync_to(mast_aladin_sync_adapter, aspects=["center", "fov", "rotation"])
 
         # assert that the view has changed as expected
+        # TODO (2026-07-22): the jdaviz glue viewer attribute `aid`
+        # will be removed in a PR coming soon, the line below will
+        # need to be updated.
         center = imviz_sync_adapter.aid.get_viewport(sky_or_pixel="sky")[AIDA_aspects.CENTER]
-        aladin_center = mast_aladin_sync_adapter.aid.get_viewport()["center"]
+        aladin_center = mast_aladin_sync_adapter.viewer.get_viewport()["center"]
         assert center.ra.deg == approx(aladin_center.ra.deg, rel=1e-8)
         assert center.dec.deg == approx(aladin_center.dec.deg, rel=1e-8)

--- a/mast_aladin/tests/test_aida_example.py
+++ b/mast_aladin/tests/test_aida_example.py
@@ -16,8 +16,7 @@ def assert_angle_close(angle1, angle2, atol=1 * u.arcsec):
 
 
 def test_mast_aladin_has_aid(MastAladin_app):
-    assert hasattr(MastAladin_app, 'aid')
-    assert callable(getattr(MastAladin_app.aid, 'set_viewport', None))
+    assert callable(getattr(MastAladin_app, 'set_viewport', None))
 
 
 def test_mast_aladin_aid_set_viewport(MastAladin_app):
@@ -45,7 +44,7 @@ def test_mast_aladin_aid_set_viewport(MastAladin_app):
         'x': Angle(45, unit='deg'),
         'y': Angle(30, unit='deg'),
     }
-    MastAladin_app.aid.set_viewport(
+    MastAladin_app.set_viewport(
         center=target_coords,
         fov=target_fov["y"],
         rotation=target_rotation,
@@ -61,7 +60,7 @@ def test_mast_aladin_aid_get_viewport(MastAladin_app):
     # check that the default center coordinate is (0, 0) deg,
     # the default fov is 60.0 deg, and the image_label is None
     default_center = SkyCoord(0, 0, unit='deg')
-    default_viewport = MastAladin_app.aid.get_viewport()
+    default_viewport = MastAladin_app.get_viewport()
     assert_coordinate_close(default_viewport["center"], default_center)
     assert_angle_close(Angle(60, u.deg), default_viewport["fov"])
     assert default_viewport["image_label"] is None
@@ -72,28 +71,28 @@ def test_mast_aladin_aid_get_and_set_viewport_roundtrip(MastAladin_app):
     # viewport results in the original state
 
     # get default settings
-    default_viewport = MastAladin_app.aid.get_viewport()
+    default_viewport = MastAladin_app.get_viewport()
 
     # change viewport settings
     target_coords = SkyCoord(45, 45, unit='deg')
     target_rotation = Angle(45, unit='deg')
-    MastAladin_app.aid.set_viewport(center=target_coords, rotation=target_rotation)
+    MastAladin_app.set_viewport(center=target_coords, rotation=target_rotation)
 
     # check new viewport settings
-    midpoint_viewport = MastAladin_app.aid.get_viewport()
+    midpoint_viewport = MastAladin_app.get_viewport()
     assert_coordinate_close(midpoint_viewport["center"], target_coords)
     assert_angle_close(midpoint_viewport["rotation"], target_rotation)
     assert_angle_close(midpoint_viewport["fov"], Angle(60, u.deg))
     assert midpoint_viewport["image_label"] is None
 
     # change viewport settings back to default
-    MastAladin_app.aid.set_viewport(
+    MastAladin_app.set_viewport(
         center=default_viewport["center"],
         rotation=default_viewport["rotation"]
     )
 
     # check final viewport settings
-    final_viewport = MastAladin_app.aid.get_viewport()
+    final_viewport = MastAladin_app.get_viewport()
     assert_coordinate_close(final_viewport["center"], default_viewport["center"])
     assert_angle_close(final_viewport["rotation"], default_viewport["rotation"])
     assert_angle_close(final_viewport["fov"], default_viewport["fov"])

--- a/notebooks/AIDA_fov_getting_and_setting.ipynb
+++ b/notebooks/AIDA_fov_getting_and_setting.ipynb
@@ -56,7 +56,7 @@
    "outputs": [],
    "source": [
     "# retrieve initial fov and fov_xy, the x-fov should be 60, so check that\n",
-    "init_fov = mast_aladin.aid.get_viewport()[\"fov\"]\n",
+    "init_fov = mast_aladin.get_viewport()[\"fov\"]\n",
     "init_fov_xy = mast_aladin._fov_xy\n",
     "\n",
     "if not assert_value_close(init_fov_xy[\"x\"], 60, 1e-5):\n",
@@ -76,7 +76,7 @@
     "    'x' : Angle(60, unit='deg'), \n",
     "    'y' : Angle(40, unit='deg'),\n",
     "}\n",
-    "mast_aladin.aid.set_viewport(\n",
+    "mast_aladin.set_viewport(\n",
     "    fov=target_fov[\"y\"]\n",
     ")"
    ]
@@ -89,7 +89,7 @@
    "outputs": [],
    "source": [
     "# retrieve midpoint fov and fov_xy, the y-fov should be 40, so check that\n",
-    "midpoint_fov = mast_aladin.aid.get_viewport()[\"fov\"]\n",
+    "midpoint_fov = mast_aladin.get_viewport()[\"fov\"]\n",
     "midpoint_fov_xy = mast_aladin._fov_xy\n",
     "\n",
     "assert_angle_close(midpoint_fov, target_fov[\"y\"], atol=1*u.deg)"
@@ -104,7 +104,7 @@
    "source": [
     "# now, we want to return to our starting fov, so let's check that setting and retrieving those\n",
     "# in turn does what's expected\n",
-    "mast_aladin.aid.set_viewport(\n",
+    "mast_aladin.set_viewport(\n",
     "    fov=init_fov_xy[\"y\"]\n",
     ")"
    ]
@@ -117,7 +117,7 @@
    "outputs": [],
    "source": [
     "# retrieve final fov and fov_xy, the x and y fov initial and final should match, so check that\n",
-    "final_fov = mast_aladin.aid.get_viewport()[\"fov\"]\n",
+    "final_fov = mast_aladin.get_viewport()[\"fov\"]\n",
     "final_fov_xy = mast_aladin._fov_xy\n",
     "\n",
     "if not assert_value_close(final_fov_xy[\"x\"], init_fov_xy[\"x\"], atol=1e-3):\n",

--- a/notebooks/AIDA_mixin_get_viewport.ipynb
+++ b/notebooks/AIDA_mixin_get_viewport.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "# Recentering on corner of earlier polygon\n",
-    "mast_aladin.aid.set_viewport(SkyCoord(269.986903302, 65.984279763, unit=\"deg\"))"
+    "mast_aladin.set_viewport(SkyCoord(269.986903302, 65.984279763, unit=\"deg\"))"
    ]
   },
   {
@@ -58,7 +58,7 @@
    "outputs": [],
    "source": [
     "# Get this viewport state for later\n",
-    "viewport_state = mast_aladin.aid.get_viewport()\n",
+    "viewport_state = mast_aladin.get_viewport()\n",
     "viewport_state"
    ]
   },
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "# Center the viewer on RA=0 deg, Dec=0 deg\n",
-    "mast_aladin.aid.set_viewport(center=SkyCoord(0,0, unit=\"deg\"))"
+    "mast_aladin.set_viewport(center=SkyCoord(0,0, unit=\"deg\"))"
    ]
   },
   {
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "# Now, let's return the viewport to the state that centers on the corner of the eartlier polygon\n",
-    "mast_aladin.aid.set_viewport(viewport_state[\"center\"])"
+    "mast_aladin.set_viewport(viewport_state[\"center\"])"
    ]
   },
   {
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "# Raises NotImplementedError since mast-aladin has no concept of pixels\n",
-    "mast_aladin.aid.get_viewport(sky_or_pixel=\"pixel\")"
+    "mast_aladin.get_viewport(sky_or_pixel=\"pixel\")"
    ]
   },
   {
@@ -103,7 +103,7 @@
    "outputs": [],
    "source": [
     "# Raises warning since mast-aladin only shows one image and has no concept of labels\n",
-    "mast_aladin.aid.get_viewport(image_label = \"image1\")"
+    "mast_aladin.get_viewport(image_label = \"image1\")"
    ]
   },
   {
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mast_aladin.aid.get_viewport?"
+    "mast_aladin.get_viewport?"
    ]
   }
  ],

--- a/notebooks/AIDA_mixin_getset_viewport_with_rotation.ipynb
+++ b/notebooks/AIDA_mixin_getset_viewport_with_rotation.ipynb
@@ -59,7 +59,7 @@
    "outputs": [],
    "source": [
     "# Recentering on corner of earlier polygon\n",
-    "mast_aladin.aid.set_viewport(\n",
+    "mast_aladin.set_viewport(\n",
     "    SkyCoord(269.986903302, 65.984279763, unit=\"deg\"),\n",
     "    Angle(0, unit=\"deg\"),\n",
     ")"
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "# Get this viewport state for later\n",
-    "viewport_state = mast_aladin.aid.get_viewport()\n",
+    "viewport_state = mast_aladin.get_viewport()\n",
     "viewport_state"
    ]
   },
@@ -85,7 +85,7 @@
    "outputs": [],
    "source": [
     "# Center the viewer on RA=0 deg, Dec=0 deg, set rotation to 180 deg, and change the projection to \"TAN\"\n",
-    "mast_aladin.aid.set_viewport(\n",
+    "mast_aladin.set_viewport(\n",
     "    center=SkyCoord(0,0, unit=\"deg\"),\n",
     "    rotation=Angle(180, unit=\"deg\"),\n",
     "    projection=\"TAN\",\n",
@@ -100,7 +100,7 @@
    "outputs": [],
    "source": [
     "# Now, let's return the viewport to the state that centers on the corner of the eartlier polygon\n",
-    "mast_aladin.aid.set_viewport(\n",
+    "mast_aladin.set_viewport(\n",
     "    center = viewport_state[\"center\"],\n",
     "    rotation = viewport_state[\"rotation\"],\n",
     "    projection = viewport_state[\"projection\"],\n",
@@ -115,7 +115,7 @@
    "outputs": [],
    "source": [
     "# Raises NotImplementedError since mast-aladin has no concept of pixels\n",
-    "mast_aladin.aid.get_viewport(sky_or_pixel=\"pixel\")"
+    "mast_aladin.get_viewport(sky_or_pixel=\"pixel\")"
    ]
   },
   {
@@ -126,7 +126,7 @@
    "outputs": [],
    "source": [
     "# Raises warning since mast-aladin only shows one image and has no concept of labels\n",
-    "mast_aladin.aid.get_viewport(image_label = \"image1\")"
+    "mast_aladin.get_viewport(image_label = \"image1\")"
    ]
   },
   {
@@ -136,7 +136,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mast_aladin.aid.get_viewport?"
+    "mast_aladin.get_viewport?"
    ]
   },
   {

--- a/notebooks/AIDA_mixin_set_viewport.ipynb
+++ b/notebooks/AIDA_mixin_set_viewport.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "# Center the viewer on RA=0 deg, Dec=0 deg\n",
-    "mast_aladin.aid.set_viewport(center=SkyCoord(0,0, unit=\"deg\"))"
+    "mast_aladin.set_viewport(center=SkyCoord(0,0, unit=\"deg\"))"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "# Recentering on corner of earlier polygon\n",
-    "mast_aladin.aid.set_viewport(SkyCoord(269.986903302, 65.984279763, unit=\"deg\"))"
+    "mast_aladin.set_viewport(SkyCoord(269.986903302, 65.984279763, unit=\"deg\"))"
    ]
   },
   {
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "# Let's change the projection to TAN\n",
-    "mast_aladin.aid.set_viewport(projection=\"TAN\")"
+    "mast_aladin.set_viewport(projection=\"TAN\")"
    ]
   },
   {
@@ -82,7 +82,7 @@
    "outputs": [],
    "source": [
     "# Raises TypeError since did not provide SkyCoord\n",
-    "mast_aladin.aid.set_viewport(center=\"0 0\")"
+    "mast_aladin.set_viewport(center=\"0 0\")"
    ]
   },
   {
@@ -93,7 +93,7 @@
    "outputs": [],
    "source": [
     "# Raises TypeError since did not provide SkyCoord\n",
-    "mast_aladin.aid.set_viewport(\"17 59 59.92 +65 54 00.3\")"
+    "mast_aladin.set_viewport(\"17 59 59.92 +65 54 00.3\")"
    ]
   },
   {
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mast_aladin.aid.set_viewport?"
+    "mast_aladin.set_viewport?"
    ]
   }
  ],

--- a/notebooks/Intro_To_Mast_Aladin.ipynb
+++ b/notebooks/Intro_To_Mast_Aladin.ipynb
@@ -186,7 +186,7 @@
    "outputs": [],
    "source": [
     "# Get the current viewport (center and zoom)\n",
-    "viewport = mast_aladin.aid.get_viewport()\n",
+    "viewport = mast_aladin.get_viewport()\n",
     "viewport"
    ]
   },
@@ -206,7 +206,7 @@
    "outputs": [],
    "source": [
     "# Reset the viewport using the saved center\n",
-    "mast_aladin.aid.set_viewport(center=viewport[\"center\"])"
+    "mast_aladin.set_viewport(center=viewport[\"center\"])"
    ]
   },
   {
@@ -297,7 +297,7 @@
     "## About this Notebook\n",
     "**Author:** Hatice Karatay\n",
     "\n",
-    "**Updated On:** 2025-09-11\n",
+    "**Updated On:** 2026-07-22\n",
     "***\n",
     "[Top of Page](#top)\n",
     "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "

--- a/notebooks/demo-delayed-methods.ipynb
+++ b/notebooks/demo-delayed-methods.ipynb
@@ -80,7 +80,7 @@
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "    Note: you'll need to zoom in to see the image and its bounding region.\n",
-    "    Try running `mast_aladin.aid.set_viewport(fov = 0.25)` to zoom in on the area!\n",
+    "    Try running `mast_aladin.set_viewport(fov = 0.25)` to zoom in on the area!\n",
     "</div>"
    ]
   },

--- a/notebooks/demo-select-MAST-products.ipynb
+++ b/notebooks/demo-select-MAST-products.ipynb
@@ -140,7 +140,7 @@
     "\n",
     "Either click the `jdaviz` and `aladin` buttons at the bottom of the `MastTable` widget, or use the API commands below to do the same thing.\n",
     "\n",
-    "If working in `mast-aladin`, zoom into the region of interest to see the file. You can do this by running `mast_aladin.aid.set_viewport(fov = 0.25)`!"
+    "If working in `mast-aladin`, zoom into the region of interest to see the file. You can do this by running `mast_aladin.set_viewport(fov = 0.25)`!"
    ]
   },
   {


### PR DESCRIPTION
This PR refactors `AID` as a mixin class to be inherited by `MastAladin`, and removes the `MastAladin.aid` attribute. Equivalent changes will be made to jdaviz in a soon-to-come PR from @pcuste1. After both changes are made, we will be able to use:
```diff
- jdaviz_viewer.aid.set_viewport( **mast_aladin.aid.get_viewport() )
+ jdaviz_viewer.set_viewport( **mast_aladin.get_viewport() )
```

I put in a temporary workaround for the short-term asymmetry while mast-aladin loses `.aid` and jdaviz retains it.

I've added comments throughout the code and notebooks in places where `imviz_viewer.aid` is called in our code so it's easy to find the code that needs changes after @pcuste1's PR. You can search for them in the code by searching for `TODO (2026-07-22)`.

I renamed the class from `AID` to `AIDA` because that seems like a better name for the mixin that implements the astro image display API.

### Test failures

There are two test failures related to the `center` coordinates computed when syncing viewers:
```python
        # assert that the view has changed as expected
        # TODO (2026-07-22): the jdaviz glue viewer attribute `aid`
        # will be removed in a PR coming soon, the line below will
        # need to be updated.
        center = imviz_sync_adapter.aid.get_viewport(sky_or_pixel="sky")[AIDA_aspects.CENTER]
        aladin_center = mast_aladin_sync_adapter.viewer.get_viewport()["center"]
>       assert center.ra.deg == approx(aladin_center.ra.deg, rel=1e-8)
E       assert np.float64(9.425937637864706) == 9.4213055 ± 9.4e-08
E         
E         comparison failed
E         Obtained: 9.425937637864706
E         Expected: 9.4213055 ± 9.4e-08
```

The difference between the actual and expected viewport centers is larger than the acceptable tolerance. I'm not sure how this happens, I'm hopeful @pcuste1 or @cpparts has an idea.